### PR TITLE
Currency domain model

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -27,6 +27,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>

--- a/backend/src/main/java/com/dfc/exchange_api/backend/controllers/TestController.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/controllers/TestController.java
@@ -1,6 +1,7 @@
 package com.dfc.exchange_api.backend.controllers;
 
 import com.dfc.exchange_api.backend.services.ExternalApiService;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -18,10 +19,9 @@ public class TestController {
     @Autowired
     ExternalApiService externalApiService;
 
-    @GetMapping("latest/{base}")
-    public ResponseEntity<JsonObject> getLatestsExchange(@PathVariable(name = "base") String base,
-                                                         @RequestParam(name = "symbols", required = false) Optional<String> symbols) throws URISyntaxException {
+    @GetMapping("latest")
+    public ResponseEntity<JsonObject> getLatestsExchange() throws URISyntaxException {
 
-        return ResponseEntity.ok().body(externalApiService.getLatestExchanges(base, symbols));
+        return ResponseEntity.ok().body(externalApiService.getAvailableCurrencies());
     }
 }

--- a/backend/src/main/java/com/dfc/exchange_api/backend/models/Currency.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/models/Currency.java
@@ -1,0 +1,26 @@
+package com.dfc.exchange_api.backend.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+/**
+ * Domain entity representing the supported Currencies
+ */
+@Entity
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode
+public class Currency {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String code;
+}

--- a/backend/src/main/java/com/dfc/exchange_api/backend/models/Currency.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/models/Currency.java
@@ -23,4 +23,9 @@ public class Currency {
 
     private String name;
     private String code;
+
+    public Currency(String name, String code) {
+        this.name = name;
+        this.code = code;
+    }
 }

--- a/backend/src/main/java/com/dfc/exchange_api/backend/repositories/CurrencyRepository.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/repositories/CurrencyRepository.java
@@ -1,0 +1,9 @@
+package com.dfc.exchange_api.backend.repositories;
+
+import com.dfc.exchange_api.backend.models.Currency;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CurrencyRepository extends JpaRepository<Currency, Long> {
+}

--- a/backend/src/main/java/com/dfc/exchange_api/backend/utils/CurrencyDatabaseInitialization.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/utils/CurrencyDatabaseInitialization.java
@@ -1,0 +1,32 @@
+package com.dfc.exchange_api.backend.utils;
+
+import com.dfc.exchange_api.backend.repositories.CurrencyRepository;
+import com.dfc.exchange_api.backend.services.ExternalApiService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class defines a bean responsible for fetching the supported currencies from the external API, and then creating
+ * the corresponding Currency domain entity instances on this API, storing them in the H2 in-memory database.
+ * This process is done after the application initialization finishes, using CommandLineRunner, and the /symbols endpoint
+ * of the external API.
+ */
+@Component
+public class CurrencyDatabaseInitialization implements CommandLineRunner {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CurrencyDatabaseInitialization.class);
+
+    private CurrencyRepository currencyRepository;
+    private ExternalApiService externalApiService;
+
+    public CurrencyDatabaseInitialization(CurrencyRepository currencyRepository, ExternalApiService externalApiService) {
+        this.currencyRepository = currencyRepository;
+        this.externalApiService = externalApiService;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+
+    }
+}

--- a/backend/src/main/java/com/dfc/exchange_api/backend/utils/CurrencyDatabaseInitialization.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/utils/CurrencyDatabaseInitialization.java
@@ -1,11 +1,18 @@
 package com.dfc.exchange_api.backend.utils;
 
+import com.dfc.exchange_api.backend.models.Currency;
 import com.dfc.exchange_api.backend.repositories.CurrencyRepository;
 import com.dfc.exchange_api.backend.services.ExternalApiService;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This class defines a bean responsible for fetching the supported currencies from the external API, and then creating
@@ -25,8 +32,33 @@ public class CurrencyDatabaseInitialization implements CommandLineRunner {
         this.externalApiService = externalApiService;
     }
 
+    /**
+     * This method will fetch the supported currencies form the External API. To do so, it will contacte the /symbols
+     * endpoint. Then, it will aprse the obtained JSON Object, corresponding to an array in which each entry is a currency,
+     * and will create an instance of the Currency object. In the end, it will save all Currency objects in the currency repository,
+     * thus storing it in the in-memory H2 database.
+     * @param args
+     * @throws Exception
+     */
     @Override
     public void run(String... args) throws Exception {
+        List<Currency> supportedCurrencies = new ArrayList<>();
 
+        // Fetching supported currencies by the external API
+        LOGGER.info("Fetching list of supported currencies by the external API....");
+        JsonObject currenciesJSON = externalApiService.getAvailableCurrencies();
+
+        for (Map.Entry<String, JsonElement> entry: currenciesJSON.entrySet()){
+            JsonObject currentObject = entry.getValue().getAsJsonObject(); // {"description": ..., "code": ....}
+            Currency currentCurrency = new Currency(currentObject.getAsJsonPrimitive("description").getAsString(),
+                    currentObject.getAsJsonPrimitive("code").getAsString());
+
+            LOGGER.info("Fetched currency: " + currentCurrency.toString());
+            supportedCurrencies.add(currentCurrency);
+        }
+
+        // Adding the currencies to the in-memory database
+        LOGGER.info("Finalized fetching all supported currencies.");
+        currencyRepository.saveAll(supportedCurrencies);
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,3 +1,13 @@
 # Spring Doc Swagger API context path
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
+
+# Configuring the H2 in-memory database
+spring.datasource.url=jdbc:h2:mem:exchangeapi
+spring.datasource.driver-class-name=org.h2.Driver
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=create
+
+spring.datasource.username=admin
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExternalApiService_unitTest.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExternalApiService_unitTest.java
@@ -65,6 +65,7 @@ public class ExternalApiService_unitTest {
         // Verify the result is as expected
         JsonObject response = externalApiService.getLatestExchanges("EUR", Optional.empty());
         assertThat(response.has("AED")).isEqualTo(true);
+        assertThat(response.has("motd")).isEqualTo(false);
 
         // Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
         Mockito.verify(mockRestTemplate, VerificationModeFactory.times(1)).getForObject(Mockito.any(), Mockito.any());
@@ -97,6 +98,7 @@ public class ExternalApiService_unitTest {
         assertThat(response.has("USD")).isEqualTo(true);
         assertThat(response.has("GBP")).isEqualTo(true);
         assertThat(response.has("AMD")).isEqualTo(false);
+        assertThat(response.has("motd")).isEqualTo(false);
 
         // Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
         Mockito.verify(mockRestTemplate, VerificationModeFactory.times(1)).getForObject(Mockito.any(), Mockito.any());
@@ -170,5 +172,52 @@ public class ExternalApiService_unitTest {
 
         // Verify the result is as expected
         assertThatThrownBy(() -> externalApiService.getConversionValues("GBP", "EUR", 65.0)).isInstanceOf(ExternalApiConnectionError.class);
+    }
+
+    @Test
+    void whenGetAvailableCurrencies_returnsSuccess() throws URISyntaxException {
+        // Set up Expectations
+        URI uri = new URI(BASE_URL + "/symbols");
+
+        String mockResponse = "{" +
+                "\"motd\": {" +
+                "\"msg\": \"If you or your company use this project or like what we doing, please consider backing us so we can continue maintaining and evolving this project.\"," +
+                "\"url\": \"https://exchangerate.host/#/donate\"" +
+                "}," +
+                "\"success\": true," +
+                "\"symbols\": {" +
+                "\"AED\": {" +
+                "\"description\": \"United Arab Emirates Dirham\"," +
+                "\"code\": \"AED\"" +
+                "}," +
+                "\"AFN\": {" +
+                "\"description\": \"Afghan Afghani\"," +
+                "\"code\": \"AFN\"" +
+                "}," +
+                "\"ZAR\": {" +
+                "\"description\": \"South African Rand\"," +
+                "\"code\": \"ZAR\"" +
+                "}," +
+                "\"ZMW\": {" +
+                "\"description\": \"Zambian Kwacha\"," +
+                "\"code\": \"ZMW\"" +
+                "}," +
+                "\"ZWL\": {" +
+                "\"description\": \"Zimbabwean Dollar\"," +
+                "\"code\": \"ZWL\"" +
+                "}" +
+                "}" +
+                "}";
+
+        when(mockRestTemplate.getForObject(uri, String.class)).thenReturn(mockResponse);
+
+        // Verify the result is as expected
+        JsonObject response = externalApiService.getAvailableCurrencies();
+        assertThat(response.has("AED")).isEqualTo(true);
+        assertThat(response.has("ZWL")).isEqualTo(true);
+        assertThat(response.has("motd")).isEqualTo(false);
+
+        // Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
+        Mockito.verify(mockRestTemplate, VerificationModeFactory.times(1)).getForObject(Mockito.any(), Mockito.any());
     }
 }


### PR DESCRIPTION
Logic to fetch the supported currencies by the external Exchange Rate API, and then add them to the domain model of our API.

To do so, by using the CommandLineRunner, at startup the application is prompted to fetch the supported symbols at the /symbols endpoint. It then instantiates an object of the Currency domain model for each supported currency, adding them to the CurrencyRepository, and thus, storing it in the in-memory H2 database.