### PR TITLE
Cache implementation

### DIFF
--- a/backend/src/main/java/com/dfc/exchange_api/backend/BackendApplication.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/BackendApplication.java
@@ -2,6 +2,7 @@ package com.dfc.exchange_api.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -10,6 +11,7 @@ import org.springframework.web.client.RestTemplate;
 @SpringBootApplication
 @EnableRetry
 @EnableScheduling
+@EnableCaching
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/dfc/exchange_api/backend/config/CacheConfig.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/config/CacheConfig.java
@@ -1,0 +1,25 @@
+package com.dfc.exchange_api.backend.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class CacheConfig {
+    @Bean
+    public Caffeine<Object, Object> caffeineConfig() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(60, TimeUnit.SECONDS);
+    }
+
+    @Bean
+    public CacheManager cacheManager(Caffeine caffeine) {
+        CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
+        caffeineCacheManager.setCaffeine(caffeine);
+        return caffeineCacheManager;
+    }
+}

--- a/backend/src/main/java/com/dfc/exchange_api/backend/controllers/ConversionController.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/controllers/ConversionController.java
@@ -57,7 +57,7 @@ public class ConversionController {
             throws InvalidCurrencyException, ExternalApiConnectionError {
         LOGGER.info("Received a request on the /convert/{from} endpoint");
 
-        return ResponseEntity.ok().body(conversionService.getConversionForSpecificCurrency(from, to, amount));
+        return ResponseEntity.ok().body(Map.of(to, conversionService.getConversionForSpecificCurrency(from, to, amount)));
     }
 
     /**

--- a/backend/src/main/java/com/dfc/exchange_api/backend/controllers/ExchangeController.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/controllers/ExchangeController.java
@@ -52,7 +52,7 @@ public class ExchangeController {
             throws InvalidCurrencyException, ExternalApiConnectionError {
         LOGGER.info("Received a request on the /exchange/{currency} endpoint");
 
-        return ResponseEntity.ok().body(exchangeService.getExchangeRateForSpecificCurrency(from, to));
+        return ResponseEntity.ok().body(Map.of(to, exchangeService.getExchangeRateForSpecificCurrency(from, to)));
     }
 
     /**
@@ -65,7 +65,6 @@ public class ExchangeController {
      * @throws ExternalApiConnectionError - In case communication with the External API fails, this exception is thrown
      * with Http Status BAD GATEWAY.
      */
-    @GetMapping("/{from}/all")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Valid currency code",
                     content = @Content),
@@ -74,6 +73,7 @@ public class ExchangeController {
             @ApiResponse(responseCode = "402", description = "Error connecting to external API",
                     content = @Content),})
     @Operation(summary = "Get the exchange rates from a currency to all other supported currencies")
+    @GetMapping("/{from}/all")
     public ResponseEntity<Map<String, Double>> getExchangeRateForAll(
             @PathVariable(name = "from") String code)
             throws InvalidCurrencyException, ExternalApiConnectionError{

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ConversionService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ConversionService.java
@@ -7,6 +7,9 @@ import com.dfc.exchange_api.backend.repositories.CurrencyRepository;
 import com.google.gson.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -18,45 +21,88 @@ public class ConversionService {
     private ExternalApiService apiService;
     private CurrencyRepository currencyRepository;
     private CurrencyService currencyService;
+    private CacheManager cacheManager;
 
-    public ConversionService(ExternalApiService apiService, CurrencyRepository currencyRepository, CurrencyService currencyService) {
+    public ConversionService(ExternalApiService apiService, CurrencyRepository currencyRepository, CurrencyService currencyService, CacheManager cacheManager) {
         this.apiService = apiService;
         this.currencyRepository = currencyRepository;
         this.currencyService = currencyService;
+        this.cacheManager = cacheManager;
     }
 
-    public Map<String, Double> getConversionForSpecificCurrency(String fromCode, String toCode, Double amount) throws InvalidCurrencyException, ExternalApiConnectionError {
-        //TODO: Javadoc After adding cache
+    /**
+     * This method returns the conversion value of a specified amount from a Currency A to another Currency B.
+     * To do so, one of 2 executions path can happen:
+     *      1. We will fetch the exchange rate of A -> B from the exchangeRate cache,
+     *          in case it's stored there. We then calculate the conversion based on this rate.
+     *      2. If the exchanged rate of A -> B is not in the exchangeRate cache, we will fetch it from the external API, do the
+     *          conversion calculation, and store the fetched rate in its cache.
+     * @param fromCode - the code of Currency A
+     * @param toCode - the code of Currency B
+     * @param amount - the amount to be converted
+     * @return the value of the conversion
+     * @throws InvalidCurrencyException - if either of the currency codes passed as parameters by the user is not supported
+     *      * by the API, throws this exception with the HTTP Status BAD REQUEST
+     * @throws ExternalApiConnectionError - in case of an error in the connection to the External API
+     */
+    public Double getConversionForSpecificCurrency(String fromCode, String toCode, Double amount) throws InvalidCurrencyException, ExternalApiConnectionError {
         // Verifying if the passed currencies are supported by the service
         if (!this.checkIfCurrencyExists(fromCode) || !this.checkIfCurrencyExists(toCode)) {
             LOGGER.info("One of the passed currencies is not supported by the service!");
             throw new InvalidCurrencyException("Invalid currency code(s) provided!");
         }
 
-        Map<String, Double> conversionValue = new HashMap<>();
+        // Checking if exchange rate is in the Cache
+        double exchangeRate;
 
-        //TODO: Check if exchange rate is in the Cache
+        Cache exchangeRateCache = cacheManager.getCache("exchangeRate");
+        String cacheKey = fromCode + "_" + toCode;
+        Cache.ValueWrapper cachedValue = exchangeRateCache.get(cacheKey);
 
-        // Fetching from external API
-        LOGGER.info("Fetching from external API the exchange rates from {} to {}", fromCode.replaceAll(INPUT_REGEX, "_"), toCode.replaceAll(INPUT_REGEX, "_"));
-        JsonObject rates = apiService.getLatestExchanges(fromCode, Optional.of(toCode)).getAsJsonObject();
+        if(cachedValue == null){
+            // Not in cache - needs to be fetched from the External API
+            LOGGER.info("The exchange rate for {} is not in the cache", toCode);
 
-        //TODO: Add exchange Rates to Cache
+            LOGGER.info("Fetching from external API the exchange rates from {} to {}", fromCode.replaceAll(INPUT_REGEX, "_"), toCode.replaceAll(INPUT_REGEX, "_"));
+            JsonObject rates = apiService.getLatestExchanges(fromCode, Optional.of(toCode)).getAsJsonObject();
+
+            exchangeRate = rates.get(toCode).getAsDouble();
+
+            // Saving the new value in the cache
+            exchangeRateCache.put(fromCode + "_" + toCode, exchangeRate);
+
+        }else{
+            LOGGER.info("The exchange rate for {} is fetched from the cache", toCode);
+            exchangeRate = (double) cachedValue.get();
+        }
 
         // Calculating the conversion rates
-        conversionValue.put(toCode, rates.get(toCode).getAsDouble() * amount);
         LOGGER.info("Finalizing processing the call to /convert/{from} endpoint with parameters: from - {}; to - {}", fromCode.replaceAll(INPUT_REGEX, "_"), toCode.replaceAll(INPUT_REGEX,"_"));
-        return conversionValue;
+        return exchangeRate*amount;
     }
 
 
-    public Map<String, Double> getConversionForVariousCurrencies(String code, String toCurrencies, Double amount) throws InvalidCurrencyException, ExternalApiConnectionError {
-        //TODO: Javadoc After adding cache
+    /**
+     * This method returns the conversion value of a specified amount from a Currency A to a list of Currencies B desired by the user.
+     * To do so, one of 2 executions path can happen for each of the currencies in list B:
+     *      1. If it's not in the conversionValue cache, we will fetch the exchange rate of A -> B from the exchangeRate cache,
+     *          in case it's stored there. We then calculate the conversion based on this rate.
+     *      2. If the exchanged rate of A -> B is not in the exchangeRate cache, we will fetch it from the external API, do the
+     *          conversion calculation, and store the fetched rate in its cache.
+     * @param fromCode - the fromCode of Currency A
+     * @param toCurrencies - the list of supplied currencies to convert to
+     * @param amount - the desired amount to be converted
+     * @return a Map<String, Double> containing the conversion value for each supported currency (with their code being
+     * the key of the map)
+     * @throws InvalidCurrencyException - thrown when the user has passed an invalid code, with an HTTP Status BAD REQUEST
+     * @throws ExternalApiConnectionError - in case of an error in the connection to the External API
+     */
+    public Map<String, Double> getConversionForVariousCurrencies(String fromCode, String toCurrencies, Double amount) throws InvalidCurrencyException, ExternalApiConnectionError {
         // Verifying if the currencies are supported by the service
-        List<String> currencyCodes = new ArrayList<>(Arrays.asList(toCurrencies.split(",")));
-        currencyCodes.add(code);
+        List<String> currencyToConvertCodes = new ArrayList<>(Arrays.asList(toCurrencies.split(",")));
+        currencyToConvertCodes.add(fromCode);  // TO make verification easier
 
-        currencyCodes.forEach(x -> {
+        currencyToConvertCodes.forEach(x -> {
                 if (!this.checkIfCurrencyExists(x)) {
                     LOGGER.info("The passed currency {} is not supported by the service!", x);
                     throw new InvalidCurrencyException("Invalid currency code " + x + " provided!");
@@ -64,32 +110,68 @@ public class ConversionService {
             }
         );
 
+        currencyToConvertCodes.remove(fromCode);  // No need to convert to own currency
+
+        // The currencies are verified
         Map<String, Double> conversionValue = new HashMap<>();
+        Cache exchangeRateCache = cacheManager.getCache("exchangeRate");
 
-        //TODO: Check if exchange rates are in the Cache
+        StringBuilder symbolsBuilder = new StringBuilder();                 // Will store symbols of currencies to be fetched from External API
+        String symbols;                                                     // Will store the result of the StringBuilder
 
+        // Checking if the passed Currencies exchange rate is in the cache or not; If not, contacting the External API
+        currencyToConvertCodes.forEach(supportedCurrency -> {
+            // Create the cache key for current Currency
+            String exchangeCacheKey = fromCode + "_" + supportedCurrency;
 
-        // Fetching from external API
-        //TODO: Do only for coins who are not in the Cache
-        LOGGER.info("Fetching from external API the exchange rates from {} to {}", code.replaceAll(INPUT_REGEX, "_"), toCurrencies.replaceAll(INPUT_REGEX, "_"));
-        JsonObject rates = apiService.getLatestExchanges(code, Optional.of(toCurrencies)).getAsJsonObject();
+            // Try to fetch from the caches
+            Cache.ValueWrapper exchangedCachedValue = exchangeRateCache.get(exchangeCacheKey);
+
+            if (exchangedCachedValue == null) {
+                // Not in exchange cage - exchange rate needs to be retrieved from External API
+                LOGGER.info("The conversion amount of {} for {} is not in the cache", amount, supportedCurrency);
+                symbolsBuilder.append(supportedCurrency).append(",");
+            }else{
+                // ExchangeRate in ExchangeRate Cache
+                LOGGER.info("The exchange rate for {} is fetched from the cache", supportedCurrency);
+                conversionValue.put(supportedCurrency, ((double) exchangedCachedValue.get())*amount);
+            }
+        });
+
+        // In case there is the need for it, contact the external API to retrieve new exchange rates
+        if(!symbolsBuilder.isEmpty()){
+            // There are currencies not present in the cache
+            symbols = symbolsBuilder.toString();
+        }else{
+            LOGGER.info("No need to fetch exchange rates from external API");
+            return conversionValue;
+        }
+
+        // Fetching from external API for any Currency not in Cache
+        LOGGER.info("Fetching from external API the required exchange rates from {} to {}", fromCode.replaceAll(INPUT_REGEX, "_"), symbols);
+        JsonObject rates = apiService.getLatestExchanges(fromCode, Optional.of(symbols)).getAsJsonObject();
 
         for(String key: rates.keySet()){
-            //TODO: Add to cache
             Optional<Currency> exchangedCurrency = currencyRepository.findByCode(key);
 
             if(exchangedCurrency.isPresent()){
-                conversionValue.put(exchangedCurrency.get().getCode(), rates.get(key).getAsDouble() * amount);
+                String exchangedCurrencyCode = exchangedCurrency.get().getCode();
+                Double exchangeValue = rates.get(key).getAsDouble();
+
+                conversionValue.put(exchangedCurrencyCode, exchangeValue*amount);
+
+                // Saving the new exchange rate in the cache
+                exchangeRateCache.put(fromCode + "_" + exchangedCurrencyCode, exchangeValue);
             }else{
                 // A fetched currency isn't in the list of supported values. This means the list of supported symbols by the external
                 // API has been updated since application startup, or that they have conversion rates for a symbol not present
                 // in their /symbols endpoint. We should call the method to fetch currencies from the external API
-                LOGGER.info("Fetched currency with code {} was not on the repository! Contacting the fetchSupportedCurrencies() service", key);
+                LOGGER.info("Fetched currency with fromCode {} was not on the repository! Contacting the fetchSupportedCurrencies() service", key);
                 currencyService.fetchSupportedCurrencies();
             }
         }
 
-        LOGGER.info("Finalizing processing the call to /exchange/{currency}/all endpoint with parameters: code - {}", code);
+        LOGGER.info("Finalizing processing the call to /exchange/{currency}/all endpoint with parameters: fromCode - {}", fromCode);
         return conversionValue;
     }
 

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ConversionService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ConversionService.java
@@ -74,8 +74,9 @@ public class ConversionService {
             exchangeRate = rates.get(toCode).getAsDouble();
 
             // Saving the new value in the cache
-            exchangeRateCache.put(fromCode + "_" + toCode, exchangeRate);
-
+            if(exchangeRateCache != null){
+                exchangeRateCache.put(fromCode + "_" + toCode, exchangeRate);
+            }
         }else{
             LOGGER.info("The exchange rate for {} is fetched from the cache", toCode.replaceAll(INPUT_REGEX, "_"));
             exchangeRate = (double) cachedValue.get();

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/CurrencyService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/CurrencyService.java
@@ -11,7 +11,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 public class CurrencyService {

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
@@ -126,7 +126,9 @@ public class ExchangeService {
                 exchangeRates.put(exchangedCurrencyCode, exchangeValue);
 
                 // Saving the new value in the cache
-                exchangeRateCache.put(fromCode + "_" + exchangedCurrencyCode, exchangeValue);
+                if(exchangeRateCache != null){
+                    exchangeRateCache.put(fromCode + "_" + exchangedCurrencyCode, exchangeValue);
+                }
             }else{
                 // A fetched currency isn't in the list of supported values. This means the list of supported symbols by the external
                 // API has been updated since application startup, or that they have conversion rates for a symbol not present

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ExternalApiService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ExternalApiService.java
@@ -57,29 +57,6 @@ public class ExternalApiService {
     }
 
     /**
-     * This method contacts the /conversion endpoint in the Exchange Rate API, which converts a value from currency A
-     * to currency B using the latest conversion rate between both.
-     * In this case, the method will parse the fetched JSON response and return a JsonElement to be used by the other service
-     * methods that depend on this endpoint.
-     * In case the External API doesn't reply with an HTTP STATUS OK message, either a customized exception is thrown, or
-     * the endpoint is contacted again using @Retryable, in the case of a TIMEOUT.
-     * @param from - the Currency from which the converted value is taken from
-     * @param to - the Currency to which the conversion is made
-     * @param amount - quantity to be converted
-     * @return a JSON Primitive with the value of the conversion
-     * @throws ExternalApiConnectionError
-     */
-    public JsonElement getConversionValues(String from, String to, Double amount) throws ExternalApiConnectionError {
-        // Calling the External API
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(BASE_URL).path("/convert")
-                .queryParam("from", from).queryParam("to", to).queryParam("amount", amount);
-        URI uri = uriBuilder.build().toUri();
-
-        // Calling the endpoint and fetching the required JsonElement
-        return this.doHttpGet(uri, "result", true);
-    }
-
-    /**
      * This method contacts the /symbols endpoint in the external API, retrieving the full list of supported currencies
      * by said API.
      * @return JsonArray, in which each element holds the description and code for each currency.

--- a/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ConversionController_withMockService_BT_Tests.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ConversionController_withMockService_BT_Tests.java
@@ -95,10 +95,7 @@ class Test_ConversionController_withMockService_BT_Tests {
 
     @Test
     void whenGettingConversionForSpecificCurrency_withValidInput_thenReturnOK() throws Exception {
-        Map<String, Double> returnedExchanges = new HashMap<>();
-        returnedExchanges.put("USD", 54.4212);
-
-        when(conversionService.getConversionForSpecificCurrency("EUR", "USD", 50.0)).thenReturn(returnedExchanges);
+        when(conversionService.getConversionForSpecificCurrency("EUR", "USD", 50.0)).thenReturn(54.4212);
 
         mockMvc.perform(
                         get("/api/v1/convert/EUR")

--- a/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ExchangeController_withMockService_BT_Tests.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ExchangeController_withMockService_BT_Tests.java
@@ -65,10 +65,7 @@ class Test_ExchangeController_withMockService_BT_Tests {
 
     @Test
     void whenGettingExchangeRateForSpecificCurrency_withValidInput_thenReturnOK() throws Exception {
-        Map<String, Double> returnedExchanges = new HashMap<>();
-        returnedExchanges.put("USD", 1.088424);
-
-        when(exchangeService.getExchangeRateForSpecificCurrency("EUR", "USD")).thenReturn(returnedExchanges);
+        when(exchangeService.getExchangeRateForSpecificCurrency("EUR", "USD")).thenReturn(1.088424);
 
         mockMvc.perform(
                         get("/api/v1/exchange/EUR")

--- a/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/ConversionController_IT.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/ConversionController_IT.java
@@ -1,12 +1,18 @@
 package com.dfc.exchange_api.backend.integrationTests;
 
 import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 
@@ -18,6 +24,22 @@ class ConversionController_IT {
     @LocalServerPort
     int randomServerPort;
 
+    @Autowired
+    CacheManager cacheManager;
+
+    private Cache exchangeRateCache;
+
+    @BeforeEach
+    void setUp(){
+        this.exchangeRateCache = cacheManager.getCache("exchangeRate");
+    }
+
+    @AfterEach
+    void tearDown(){
+        this.exchangeRateCache.clear();
+        this.exchangeRateCache = null;
+    }
+
     @Test
     void whenGettingConversionForVarious_withValidInput_NotInCache_thenContactExternalAPI() {
         RestAssured.given().contentType("application/json")
@@ -28,12 +50,25 @@ class ConversionController_IT {
                 .assertThat()
                 .body("$", hasKey("USD")).and()
                 .body("$", hasKey("GBP"));
+
+        // Verify that values were added to the Cache
+        assertThat(this.exchangeRateCache.get("EUR_USD")).isNotNull();
+        assertThat(this.exchangeRateCache.get("EUR_GBP")).isNotNull();
     }
 
     @Test
-    @Disabled
     void whenGettingConversionForVarious_withValidInput_InCache_thenSearchInCache() {
+        this.exchangeRateCache.put("EUR_USD", 100.88186);
 
+        RestAssured.given().contentType("application/json")
+                .when()
+                .get(BASE_URL + randomServerPort + "/api/v1/convert/EUR/various?to=USD,GBP&amount=50.0")
+                .then()
+                .statusCode(200)
+                .assertThat()
+                .body("$", hasKey("USD")).and()
+                .body("$", hasKey("GBP")).and()
+                .body("USD", equalTo(5044.093F));
     }
 
     @Test
@@ -74,12 +109,23 @@ class ConversionController_IT {
                 .statusCode(200)
                 .assertThat()
                 .body("$", hasKey("USD"));
+
+        // Verify that values were added to the Cache
+        assertThat(this.exchangeRateCache.get("EUR_USD")).isNotNull();
     }
 
     @Test
-    @Disabled
     void whenGettingConversionForSpecificCurrency_withValidInput_InCache_thenSearchInCache() {
+        this.exchangeRateCache.put("EUR_USD", 100.88186);
 
+        RestAssured.given().contentType("application/json")
+                .when()
+                .get(BASE_URL + randomServerPort + "/api/v1/convert/EUR?to=USD&amount=50.0")
+                .then()
+                .statusCode(200)
+                .assertThat()
+                .body("$", hasKey("USD")).and()
+                .body("USD", equalTo(5044.093F));
     }
 
 

--- a/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ConversionService_unitTest.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ConversionService_unitTest.java
@@ -5,18 +5,22 @@ import com.dfc.exchange_api.backend.exceptions.InvalidCurrencyException;
 import com.dfc.exchange_api.backend.models.Currency;
 import com.dfc.exchange_api.backend.repositories.CurrencyRepository;
 import com.dfc.exchange_api.backend.services.ConversionService;
+import com.dfc.exchange_api.backend.services.CurrencyService;
 import com.dfc.exchange_api.backend.services.ExternalApiService;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -31,6 +35,12 @@ class ConversionService_unitTest {
     ExternalApiService externalApiService;
     @Mock(lenient = true)
     CurrencyRepository currencyRepository;
+    @Mock
+    private CurrencyService currencyService;
+    @Mock
+    private CacheManager cacheManager;
+    @Mock
+    private Cache exchangeRateCache;
 
     @InjectMocks
     ConversionService conversionService;
@@ -38,14 +48,14 @@ class ConversionService_unitTest {
     Currency euro;
     Currency dollar;
     Currency dram;
-    Currency guilder;
+    List<Currency> testCurrencies;
 
     @BeforeEach
     void setUp() {
         euro = new Currency("Euro", "EUR");
         dollar = new Currency("United States Dollar", "USD");
         dram = new Currency("Armenian Dram", "AMD");
-        guilder = new Currency("Netherlands Antillean Guilder", "ANG");
+        testCurrencies = List.of(euro, dollar, dram);
     }
 
     @AfterEach
@@ -53,7 +63,7 @@ class ConversionService_unitTest {
         euro = null;
         dollar = null;
         dram = null;
-        guilder = null;
+        testCurrencies = null;
     }
 
     @Test
@@ -70,43 +80,127 @@ class ConversionService_unitTest {
                 "    \"date\": \"2023-08-17\",\n" +
                 "    \"rates\": {\n" +
                 "        \"AMD\": 422.228721,\n" +
-                "        \"ANG\": 1.965639,\n" +
                 "        \"USD\": 1.088186\n" +
                 "    }\n" +
                 "}";
 
         JsonElement rates = JsonParser.parseString(mockResponse).getAsJsonObject().get("rates");
 
-        when(externalApiService.getLatestExchanges("EUR", Optional.of("AMD,ANG,USD"))).thenReturn(rates);
+        when(externalApiService.getLatestExchanges("EUR", Optional.of("AMD,USD,"))).thenReturn(rates);
+
+        // Repository calls
         when(currencyRepository.existsByCode("EUR")).thenReturn(true);
         when(currencyRepository.existsByCode("AMD")).thenReturn(true);
-        when(currencyRepository.existsByCode("ANG")).thenReturn(true);
         when(currencyRepository.existsByCode("USD")).thenReturn(true);
+
         when(currencyRepository.findByCode("AMD")).thenReturn(Optional.of(dram));
-        when(currencyRepository.findByCode("ANG")).thenReturn(Optional.of(guilder));
         when(currencyRepository.findByCode("USD")).thenReturn(Optional.of(dollar));
 
+        // Cache calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+
+        when(exchangeRateCache.get("EUR_AMD")).thenReturn(null);
+        when(exchangeRateCache.get("EUR_USD")).thenReturn(null);
+
         // Verify the result is as expected
-        Map<String, Double> exchangeRate = conversionService.getConversionForVariousCurrencies("EUR", "AMD,ANG,USD", 50.0);
+        Map<String, Double> exchangeRate = conversionService.getConversionForVariousCurrencies("EUR", "AMD,USD", 50.0);
 
-        assertThat(exchangeRate).containsOnlyKeys("AMD", "ANG", "USD")
+        assertThat(exchangeRate).containsOnlyKeys("AMD", "USD")
                 .containsEntry("USD",54.4093)
-                .containsEntry("AMD",21111.43605)
-                .containsEntry("ANG",98.28195);
+                .containsEntry("AMD",21111.43605);
 
-        // TODO: Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
-        verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("AMD,ANG,USD"));
+        // Method invocation verifications
+        verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("AMD,USD,"));
+
+        verify(currencyRepository, times(1)).existsByCode("EUR");
+        verify(currencyRepository, times(2)).findByCode(Mockito.any());
+
+        verify(exchangeRateCache, times(2)).get(Mockito.any());
+
+        verify(exchangeRateCache, times(1)).put("EUR_AMD", 422.228721);
+        verify(exchangeRateCache, times(1)).put("EUR_USD", 1.088186);
     }
 
     @Test
-    @Disabled
-    void whenGettingConversionForAll_withValidInput_InConversionCache_thenSearchInConversionCache() {
+    void whenGettingConversionForAll_withValidInput_AllInExchangeCache_thenCalculateConversion() {
+        // Set up Expectations
+        // Repository calls
+        when(currencyRepository.existsByCode("EUR")).thenReturn(true);
+        when(currencyRepository.existsByCode("AMD")).thenReturn(true);
+        when(currencyRepository.existsByCode("USD")).thenReturn(true);
 
+        // Cache Calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        Cache.ValueWrapper cachedValue = mock(Cache.ValueWrapper.class);
+        when(cachedValue.get()).thenReturn(422.228721);
+
+        when(exchangeRateCache.get("EUR_AMD")).thenReturn(cachedValue);
+        when(exchangeRateCache.get("EUR_USD")).thenReturn(cachedValue);
+
+        // Verify the result is as expected
+        Map<String, Double> exchangeRate = conversionService.getConversionForVariousCurrencies("EUR", "AMD,USD", 50.0);
+
+        assertThat(exchangeRate).containsOnlyKeys("AMD", "USD")
+                .containsEntry("USD",21111.43605)
+                .containsEntry("AMD",21111.43605);
+
+        // Method invocation verifications
+        verify(currencyRepository, times(3)).existsByCode(Mockito.any());
+
+        verify(exchangeRateCache, times(2)).get(Mockito.any());
     }
 
     @Test
-    @Disabled
-    void whenGettingConversionForAll_withValidInput_InExchangeCache_thenCalculateConversion() {
+    void whenGettingConversionForAll_withValidInput_SomeInExchangeCache_thenCalculateConversion() {
+        // Set up Expectations
+        String mockResponse = "{\n" +
+                "    \"motd\": {\n" +
+                "        \"msg\": \"If you or your company use this project or like what we doing, please consider backing us so we can continue maintaining and evolving this project.\",\n" +
+                "        \"url\": \"https://exchangerate.host/#/donate\"\n" +
+                "    },\n" +
+                "    \"success\": true,\n" +
+                "    \"historical\": true,\n" +
+                "    \"base\": \"EUR\",\n" +
+                "    \"date\": \"2023-08-17\",\n" +
+                "    \"rates\": {\n" +
+                "        \"USD\": 1.088186\n" +
+                "    }\n" +
+                "}";
+
+        JsonElement rates = JsonParser.parseString(mockResponse).getAsJsonObject().get("rates");
+
+        when(externalApiService.getLatestExchanges("EUR", Optional.of("USD,"))).thenReturn(rates);
+
+        // Repository calls
+        when(currencyRepository.existsByCode("EUR")).thenReturn(true);
+        when(currencyRepository.existsByCode("AMD")).thenReturn(true);
+        when(currencyRepository.existsByCode("USD")).thenReturn(true);
+        when(currencyRepository.findByCode("AMD")).thenReturn(Optional.of(dram));
+        when(currencyRepository.findByCode("USD")).thenReturn(Optional.of(dollar));
+
+        // Cache Calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        Cache.ValueWrapper cachedValue = mock(Cache.ValueWrapper.class);
+        when(cachedValue.get()).thenReturn(422.228721);
+
+        when(exchangeRateCache.get("EUR_AMD")).thenReturn(cachedValue);
+        when(exchangeRateCache.get("EUR_USD")).thenReturn(null);
+
+        // Verify the result is as expected
+        Map<String, Double> exchangeRate = conversionService.getConversionForVariousCurrencies("EUR", "AMD,USD", 50.0);
+
+        assertThat(exchangeRate).containsOnlyKeys("AMD", "USD")
+                .containsEntry("USD",54.4093)
+                .containsEntry("AMD",21111.43605);
+
+        // Method invocation verifications
+        verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("USD,"));
+
+        verify(currencyRepository, times(3)).existsByCode(Mockito.any());
+        verify(currencyRepository, times(1)).findByCode(Mockito.any());
+
+        verify(exchangeRateCache, times(2)).get(Mockito.any());
+        verify(exchangeRateCache, times(1)).put("EUR_USD", 1.088186);
 
     }
 
@@ -115,17 +209,24 @@ class ConversionService_unitTest {
         // Set up Expectations
         when(currencyRepository.existsByCode("EUR")).thenReturn(true);
         when(currencyRepository.existsByCode("AMD")).thenReturn(true);
-        when(currencyRepository.existsByCode("ANG")).thenReturn(true);
         when(currencyRepository.existsByCode("USD")).thenReturn(true);
-        when(externalApiService.getLatestExchanges("EUR", Optional.of("AMD,ANG,USD"))).thenThrow(new ExternalApiConnectionError("External API request failed"));
+        when(externalApiService.getLatestExchanges("EUR", Optional.of("AMD,USD,"))).thenThrow(new ExternalApiConnectionError("External API request failed"));
+
+        // Cache calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+
+        when(exchangeRateCache.get("EUR_AMD")).thenReturn(null);
+        when(exchangeRateCache.get("EUR_USD")).thenReturn(null);
 
         // Verify the result is as expected
-        assertThatThrownBy(() -> conversionService.getConversionForVariousCurrencies("EUR", "AMD,ANG,USD", 50.0))
+        assertThatThrownBy(() -> conversionService.getConversionForVariousCurrencies("EUR", "AMD,USD", 50.0))
                 .isInstanceOf(ExternalApiConnectionError.class)
                 .hasMessage("External API request failed");
 
-        // TODO: Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
-        verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("AMD,ANG,USD"));
+        // Method invocation verifications
+        verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("AMD,USD,"));
+
+        verify(exchangeRateCache, times(2)).get(Mockito.any());
     }
 
     @Test
@@ -178,28 +279,46 @@ class ConversionService_unitTest {
         JsonElement rates = JsonParser.parseString(mockResponse).getAsJsonObject().get("rates");
 
         when(externalApiService.getLatestExchanges("EUR", Optional.of("USD"))).thenReturn(rates);
+
+        // Cache calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        when(exchangeRateCache.get("EUR_USD")).thenReturn(null);
+
+        // Repository Calls
         when(currencyRepository.existsByCode("EUR")).thenReturn(true);
         when(currencyRepository.existsByCode("USD")).thenReturn(true);
 
         // Verify the result is as expected
-        Map<String, Double> conversionValue = conversionService.getConversionForSpecificCurrency("EUR", "USD", 50.0);
+        Double conversionValue = conversionService.getConversionForSpecificCurrency("EUR", "USD", 50.0);
 
-        assertThat(conversionValue).containsOnlyKeys("USD").containsEntry("USD", 54.4093);
+        assertThat(conversionValue).isEqualTo(54.4093);
 
-        // TODO: Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
+        // Method invocation verifications
         verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("USD"));
+
+        verify(exchangeRateCache, times(1)).get(Mockito.any());
+        verify(exchangeRateCache, times(1)).put("EUR_USD", 1.088186);
     }
 
     @Test
-    @Disabled
-    void whenGettingConversionForSpecificCurrency_withValidInput_InConversionCache_thenSearchInConversionCache() {
-
-    }
-
-    @Test
-    @Disabled
     void whenGettingConversionForSpecificCurrency_withValidInput_InExchangeCache_thenCalculateConversion() {
+        // Cache calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        Cache.ValueWrapper cachedValue = mock(Cache.ValueWrapper.class);
+        when(cachedValue.get()).thenReturn(1.088186);
+        when(exchangeRateCache.get("EUR_USD")).thenReturn(cachedValue);
 
+        // Repository Calls
+        when(currencyRepository.existsByCode("EUR")).thenReturn(true);
+        when(currencyRepository.existsByCode("USD")).thenReturn(true);
+
+        // Verify the result is as expected
+        Double conversionValue = conversionService.getConversionForSpecificCurrency("EUR", "USD", 50.0);
+
+        assertThat(conversionValue).isEqualTo(54.4093);
+
+        // Method invocation verifications
+        verify(exchangeRateCache, times(1)).get(Mockito.any());
     }
 
     @Test
@@ -209,13 +328,19 @@ class ConversionService_unitTest {
         when(currencyRepository.existsByCode("USD")).thenReturn(true);
         when(externalApiService.getLatestExchanges("EUR", Optional.of("USD"))).thenThrow(new ExternalApiConnectionError("External API request failed"));
 
+        // Cache calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        when(exchangeRateCache.get("EUR_USD")).thenReturn(null);
+
         // Verify the result is as expected
         assertThatThrownBy(() -> conversionService.getConversionForSpecificCurrency("EUR", "USD", 50.0))
                 .isInstanceOf(ExternalApiConnectionError.class)
                 .hasMessage("External API request failed");
 
-        // TODO: Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
+        // Method invocation verifications
         verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("USD"));
+
+        verify(exchangeRateCache, times(1)).get(Mockito.any());
     }
 
     @Test

--- a/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExchangeService_unitTest.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExchangeService_unitTest.java
@@ -4,20 +4,23 @@ import com.dfc.exchange_api.backend.exceptions.ExternalApiConnectionError;
 import com.dfc.exchange_api.backend.exceptions.InvalidCurrencyException;
 import com.dfc.exchange_api.backend.models.Currency;
 import com.dfc.exchange_api.backend.repositories.CurrencyRepository;
+import com.dfc.exchange_api.backend.services.CurrencyService;
 import com.dfc.exchange_api.backend.services.ExchangeService;
 import com.dfc.exchange_api.backend.services.ExternalApiService;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 
-
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -29,9 +32,14 @@ import static org.mockito.Mockito.*;
 class ExchangeService_unitTest {
     @Mock
     private ExternalApiService externalApiService;
-
     @Mock(lenient = true)
     private CurrencyRepository currencyRepository;
+    @Mock
+    private CurrencyService currencyService;
+    @Mock
+    private CacheManager cacheManager;
+    @Mock
+    private Cache exchangeRateCache;
 
     @InjectMocks
     private ExchangeService exchangeService;
@@ -40,6 +48,7 @@ class ExchangeService_unitTest {
     Currency dollar;
     Currency dram;
     Currency guilder;
+    List<Currency> testCurrencies;
 
     @BeforeEach
     void setUp() {
@@ -47,6 +56,7 @@ class ExchangeService_unitTest {
         dollar = new Currency("United States Dollar", "USD");
         dram = new Currency("Armenian Dram", "AMD");
         guilder = new Currency("Netherlands Antillean Guilder", "ANG");
+        testCurrencies = List.of(euro, dollar, dram, guilder);
     }
 
     @AfterEach
@@ -55,11 +65,13 @@ class ExchangeService_unitTest {
         dollar = null;
         dram = null;
         guilder = null;
+        testCurrencies = null;
     }
 
     @Test
     void whenGettingExchangeRateForAll_withValidInput_NotInCache_thenContactExternalAPI() {
         // Set up Expectations
+        // External API Call
         String mockResponse = "{\n" +
                 "    \"motd\": {\n" +
                 "        \"msg\": \"If you or your company use this project or like what we doing, please consider backing us so we can continue maintaining and evolving this project.\",\n" +
@@ -78,40 +90,161 @@ class ExchangeService_unitTest {
 
         JsonElement rates = JsonParser.parseString(mockResponse).getAsJsonObject().get("rates");
 
-        when(externalApiService.getLatestExchanges("EUR", Optional.empty())).thenReturn(rates);
+        when(externalApiService.getLatestExchanges("EUR", Optional.of("EUR,USD,AMD,ANG,"))).thenReturn(rates);
+
+        // Repository calls
         when(currencyRepository.existsByCode("EUR")).thenReturn(true);
         when(currencyRepository.findByCode("AMD")).thenReturn(Optional.of(dram));
         when(currencyRepository.findByCode("ANG")).thenReturn(Optional.of(guilder));
         when(currencyRepository.findByCode("USD")).thenReturn(Optional.of(dollar));
+        when(currencyRepository.findAll()).thenReturn(testCurrencies);
+
+        // Cache calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        when(exchangeRateCache.get("EUR_AMD")).thenReturn(null);
+        when(exchangeRateCache.get("EUR_ANG")).thenReturn(null);
+        when(exchangeRateCache.get("EUR_USD")).thenReturn(null);
+        when(exchangeRateCache.get("EUR_EUR")).thenReturn(null);
 
         // Verify the result is as expected
         Map<String, Double> exchangeRate = exchangeService.getExchangeRateForAll("EUR");
 
         assertThat(exchangeRate).containsOnlyKeys("AMD", "ANG", "USD").containsEntry("USD",1.088186);
 
-        // TODO: Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
-        verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.empty());
+        // Method invocation verifications
+        verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("EUR,USD,AMD,ANG,"));
+
+        verify(currencyRepository, times(1)).existsByCode("EUR");
+        verify(currencyRepository, times(3)).findByCode(Mockito.any());
+        verify(currencyRepository, times(1)).findAll();
+
+        verify(exchangeRateCache, times(4)).get(Mockito.any());
+
+        verify(exchangeRateCache, times(1)).put("EUR_AMD", 422.228721);
+        verify(exchangeRateCache, times(1)).put("EUR_ANG", 1.965639);
+        verify(exchangeRateCache, times(1)).put("EUR_USD", 1.088186);
     }
 
     @Test
-    @Disabled
-    void whenGettingExchangeRateForAll_withValidInput_InCache_thenSearchInCache() {
+    void whenGettingExchangeRateForAll_withValidInput_AllInCache_thenSearchInCache() {
+        // Set up Expectations
+        // Repository calls
+        when(currencyRepository.existsByCode("EUR")).thenReturn(true);
+        when(currencyRepository.findAll()).thenReturn(testCurrencies);
 
+        // Cache Calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        Cache.ValueWrapper cachedValue = mock(Cache.ValueWrapper.class);
+        when(cachedValue.get()).thenReturn(422.228721);
+
+        when(exchangeRateCache.get("EUR_AMD")).thenReturn(cachedValue);
+        when(exchangeRateCache.get("EUR_ANG")).thenReturn(cachedValue);
+        when(exchangeRateCache.get("EUR_USD")).thenReturn(cachedValue);
+        when(exchangeRateCache.get("EUR_EUR")).thenReturn(cachedValue);
+
+
+        // Verify the result is as expected
+        Map<String, Double> exchangeRate = exchangeService.getExchangeRateForAll("EUR");
+
+        assertThat(exchangeRate).containsOnlyKeys("AMD", "ANG", "USD", "EUR").containsEntry("USD",422.228721);
+
+        // Method invocation verifications
+        verify(currencyRepository, times(1)).existsByCode("EUR");
+        verify(currencyRepository, times(1)).findAll();
+
+        verify(exchangeRateCache, times(4)).get(Mockito.any());
+    }
+
+    @Test
+    void whenGettingExchangeRateForAll_withValidInput_SomeInCache_thenSearchInCache() {
+        // Set up Expectations
+        // External API Call
+        String mockResponse = "{\n" +
+                "    \"motd\": {\n" +
+                "        \"msg\": \"If you or your company use this project or like what we doing, please consider backing us so we can continue maintaining and evolving this project.\",\n" +
+                "        \"url\": \"https://exchangerate.host/#/donate\"\n" +
+                "    },\n" +
+                "    \"success\": true,\n" +
+                "    \"historical\": true,\n" +
+                "    \"base\": \"EUR\",\n" +
+                "    \"date\": \"2023-08-17\",\n" +
+                "    \"rates\": {\n" +
+                "        \"AMD\": 422.228721,\n" +
+                "        \"ANG\": 1.965639\n" +
+                "    }\n" +
+                "}";
+
+        JsonElement rates = JsonParser.parseString(mockResponse).getAsJsonObject().get("rates");
+
+        when(externalApiService.getLatestExchanges("EUR", Optional.of("AMD,ANG,"))).thenReturn(rates);
+
+        // Repository calls
+        when(currencyRepository.existsByCode("EUR")).thenReturn(true);
+        when(currencyRepository.findByCode("AMD")).thenReturn(Optional.of(dram));
+        when(currencyRepository.findByCode("ANG")).thenReturn(Optional.of(guilder));
+        when(currencyRepository.findAll()).thenReturn(testCurrencies);
+
+        // Cache calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        Cache.ValueWrapper cachedValue = mock(Cache.ValueWrapper.class);
+        when(cachedValue.get()).thenReturn(422.228721);
+
+        when(exchangeRateCache.get("EUR_AMD")).thenReturn(null);
+        when(exchangeRateCache.get("EUR_ANG")).thenReturn(null);
+        when(exchangeRateCache.get("EUR_USD")).thenReturn(cachedValue);
+        when(exchangeRateCache.get("EUR_EUR")).thenReturn(cachedValue);
+
+
+        // Verify the result is as expected
+        Map<String, Double> exchangeRate = exchangeService.getExchangeRateForAll("EUR");
+
+        assertThat(exchangeRate).containsOnlyKeys("AMD", "ANG", "USD", "EUR")
+                .containsEntry("USD",422.228721)
+                .containsEntry("ANG", 1.965639);
+
+        // Method invocation verifications
+        verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("AMD,ANG,"));
+
+        verify(currencyRepository, times(1)).existsByCode("EUR");
+        verify(currencyRepository, times(2)).findByCode(Mockito.any());
+        verify(currencyRepository, times(1)).findAll();
+
+        verify(exchangeRateCache, times(4)).get(Mockito.any());
+
+        verify(exchangeRateCache, times(1)).put("EUR_AMD", 422.228721);
+        verify(exchangeRateCache, times(1)).put("EUR_ANG", 1.965639);
     }
 
     @Test
     void whenGettingExchangeRateForAll_withValidInput_NotInCache_externalAPIFailure_thenThrowException() {
         // Set up Expectations
+        when(externalApiService.getLatestExchanges("EUR", Optional.of("EUR,USD,AMD,ANG,"))).thenThrow(new ExternalApiConnectionError("External API request failed"));
+
+        // Repository calls
         when(currencyRepository.existsByCode("EUR")).thenReturn(true);
-        when(externalApiService.getLatestExchanges("EUR", Optional.empty())).thenThrow(new ExternalApiConnectionError("External API request failed"));
+        when(currencyRepository.findByCode("AMD")).thenReturn(Optional.of(dram));
+        when(currencyRepository.findByCode("ANG")).thenReturn(Optional.of(guilder));
+        when(currencyRepository.findByCode("USD")).thenReturn(Optional.of(dollar));
+        when(currencyRepository.findAll()).thenReturn(testCurrencies);
+
+        // Cache calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        when(exchangeRateCache.get("EUR_AMD")).thenReturn(null);
+        when(exchangeRateCache.get("EUR_ANG")).thenReturn(null);
+        when(exchangeRateCache.get("EUR_USD")).thenReturn(null);
+        when(exchangeRateCache.get("EUR_EUR")).thenReturn(null);
 
         // Verify the result is as expected
         assertThatThrownBy(() -> exchangeService.getExchangeRateForAll("EUR"))
                 .isInstanceOf(ExternalApiConnectionError.class)
                 .hasMessage("External API request failed");
 
-        // TODO: Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
-        verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.empty());
+        // Method invocation verifications
+        verify(currencyRepository, times(1)).existsByCode("EUR");
+        verify(currencyRepository, times(1)).findAll();
+
+        verify(exchangeRateCache, times(4)).get(Mockito.any());
+        verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("EUR,USD,AMD,ANG,"));
     }
 
     @Test
@@ -150,18 +283,12 @@ class ExchangeService_unitTest {
         when(currencyRepository.existsByCode("USD")).thenReturn(true);
 
         // Verify the result is as expected
-        Map<String, Double> exchangeRate = exchangeService.getExchangeRateForSpecificCurrency("EUR", "USD");
+        Double exchangeRate = exchangeService.getExchangeRateForSpecificCurrency("EUR", "USD");
 
-        assertThat(exchangeRate).containsOnlyKeys("USD").containsEntry("USD", 1.088186);
+        assertThat(exchangeRate).isEqualTo(1.088186);
 
         // TODO: Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
         verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("USD"));
-    }
-
-    @Test
-    @Disabled
-    void whenGettingExchangeRateForSpecificCurrency_withValidInput_InCache_thenSearchInCache() {
-
     }
 
     @Test

--- a/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExternalApiService_unitTest.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExternalApiService_unitTest.java
@@ -130,7 +130,7 @@ class ExternalApiService_unitTest {
         // Verify the result is as expected
         assertThatThrownBy(() -> externalApiService.getLatestExchanges("EUR", Optional.empty())).isInstanceOf(ExternalApiConnectionError.class);
     }
-    
+
     @Test
     void whenGetAvailableCurrencies_returnsSuccess() {
         // Set up Expectations

--- a/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExternalApiService_unitTest.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExternalApiService_unitTest.java
@@ -130,63 +130,7 @@ class ExternalApiService_unitTest {
         // Verify the result is as expected
         assertThatThrownBy(() -> externalApiService.getLatestExchanges("EUR", Optional.empty())).isInstanceOf(ExternalApiConnectionError.class);
     }
-
-    @Test
-    void whenGetConversionValues_returnsSuccess() {
-        // Set up Expectations
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(BASE_URL).path("/convert")
-                .queryParam("from", "GBP").queryParam("to", "EUR").queryParam("amount", "65.0");
-        URI uri = uriBuilder.build().toUri();
-
-        String mockResponse = "{\n" +
-                "    \"motd\": {\n" +
-                "        \"msg\": \"If you or your company use this project or like what we doing, please consider backing us so we can continue maintaining and evolving this project.\",\n" +
-                "        \"url\": \"https://exchangerate.host/#/donate\"\n" +
-                "    },\n" +
-                "    \"success\": true,\n" +
-                "    \"query\": {\n" +
-                "        \"from\": \"EUR\",\n" +
-                "        \"to\": \"GBP\",\n" +
-                "        \"amount\": 65\n" +
-                "    },\n" +
-                "    \"info\": {\n" +
-                "        \"rate\": 0.853548\n" +
-                "    },\n" +
-                "    \"historical\": false,\n" +
-                "    \"date\": \"2023-08-17\",\n" +
-                "    \"result\": 55.480632\n" +
-                "}";
-
-
-        when(mockRestTemplate.getForObject(uri, String.class)).thenReturn(mockResponse);
-
-        // Verify the result is as expected
-        JsonPrimitive response = externalApiService.getConversionValues("GBP", "EUR", 65.0).getAsJsonPrimitive();
-        assertThat(response.getAsDouble()).isEqualTo(55.480632);
-
-        // Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
-        Mockito.verify(mockRestTemplate, VerificationModeFactory.times(1)).getForObject(Mockito.any(), Mockito.any());
-    }
-
-    @Test
-    void whenGetLatestConversion_returnsBadRequest_thenThrowException() {
-        // Set up Expectations
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(BASE_URL).path("/convert")
-                .queryParam("from", "GBP").queryParam("to", "EUR").queryParam("amount", "65.0");
-        URI uri = uriBuilder.build().toUri();
-
-        MockRestServiceServer mockServer = MockRestServiceServer.createServer(mockRestTemplate);
-
-        mockServer.expect(requestTo(uri))
-                .andRespond(withStatus(HttpStatus.BAD_REQUEST)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .body("{\"error\":\"Bad request\"}"));
-
-
-        // Verify the result is as expected
-        assertThatThrownBy(() -> externalApiService.getConversionValues("GBP", "EUR", 65.0)).isInstanceOf(ExternalApiConnectionError.class);
-    }
-
+    
     @Test
     void whenGetAvailableCurrencies_returnsSuccess() {
         // Set up Expectations


### PR DESCRIPTION
- Refactored the scheduled job for fetching supported currencies in currencyService so outdated currencies that are no longer supported are removed.
- Changed the planned paradigm for the cache implementation to consist only of a cache for storing the individual exchange rates from currency A to currency B - when the rates for every currency are fetched, each cache entry is updated; when conversion values are called, the exchange rate cache is contacted, for the rate to be used in the calculation of the conversion (if it's not in the cache, the external API is contacted to fetch the exchange rate from there)
- Refactored the ConversionService and ExchangeService to reflect this cache implementation. Also refactored related unit tests, boundary tests and integration tests.
- Removed the call to get the conversion values form the External API, as this is no longer required - now, when users fetch the ConversionController endpoints, the conversion is calculated by our service instead.