### PR TITLE
Refactoring exchange conversion services

### DIFF
--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
@@ -121,18 +121,23 @@ public class ExchangeService {
     public Double getExchangeRateFromCache(String fromCode, String toCode) {
         Cache exchangeRateCache = cacheManager.getCache("exchangeRate");
 
-        // Create the cache key
-        String cacheKey = fromCode + "_" + toCode;
+        if(exchangeRateCache != null){
+            // Create the cache key
+            String cacheKey = fromCode + "_" + toCode;
 
-        // Try to fetch from the cache
-        Cache.ValueWrapper cachedValue = Optional.ofNullable(exchangeRateCache.get(cacheKey)).orElse(null);
-        if(cachedValue == null){
-            // Not in cache - needs to be fetched from the External API
-            LOGGER.info("The exchange rate for {} is not in the cache", toCode.replaceAll(INPUT_REGEX, "_"));
-            return null;
+            // Try to fetch from the cache
+            Cache.ValueWrapper cachedValue = exchangeRateCache.get(cacheKey);
+            if(cachedValue == null){
+                // Not in cache - needs to be fetched from the External API
+                LOGGER.info("The exchange rate for {} is not in the cache", toCode.replaceAll(INPUT_REGEX, "_"));
+                return null;
+            }else{
+                LOGGER.info("The exchange rate for {} is fetched from the cache", toCode.replaceAll(INPUT_REGEX, "_"));
+                return (Double) cachedValue.get();
+            }
         }else{
-            LOGGER.info("The exchange rate for {} is fetched from the cache", toCode.replaceAll(INPUT_REGEX, "_"));
-            return (Double) cachedValue.get();
+            LOGGER.info("Cache not found");
+            return null;
         }
     }
 

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
@@ -125,13 +125,13 @@ public class ExchangeService {
         String cacheKey = fromCode + "_" + toCode;
 
         // Try to fetch from the cache
-        Cache.ValueWrapper cachedValue = exchangeRateCache.get(cacheKey);
+        Cache.ValueWrapper cachedValue = Optional.ofNullable(exchangeRateCache.get(cacheKey)).orElse(null);
         if(cachedValue == null){
             // Not in cache - needs to be fetched from the External API
-            LOGGER.info("The exchange rate for {} is not in the cache", toCode);
+            LOGGER.info("The exchange rate for {} is not in the cache", toCode.replaceAll(INPUT_REGEX, "_"));
             return null;
         }else{
-            LOGGER.info("The exchange rate for {} is fetched from the cache", toCode);
+            LOGGER.info("The exchange rate for {} is fetched from the cache", toCode.replaceAll(INPUT_REGEX, "_"));
             return (Double) cachedValue.get();
         }
     }

--- a/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExchangeService_unitTest.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExchangeService_unitTest.java
@@ -281,14 +281,19 @@ class ExchangeService_unitTest {
         when(externalApiService.getLatestExchanges("EUR", Optional.of("USD"))).thenReturn(rates);
         when(currencyRepository.existsByCode("EUR")).thenReturn(true);
         when(currencyRepository.existsByCode("USD")).thenReturn(true);
+        when(currencyRepository.findByCode("USD")).thenReturn(Optional.of(dollar));
+
+        // Cache calls
+        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
 
         // Verify the result is as expected
         Double exchangeRate = exchangeService.getExchangeRateForSpecificCurrency("EUR", "USD");
 
         assertThat(exchangeRate).isEqualTo(1.088186);
 
-        // TODO: Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
+        // Method invocation verifications
         verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("USD"));
+        verify(exchangeRateCache, times(1)).put("EUR_USD", 1.088186);
     }
 
     @Test
@@ -303,7 +308,7 @@ class ExchangeService_unitTest {
                 .isInstanceOf(ExternalApiConnectionError.class)
                 .hasMessage("External API request failed");
 
-        // TODO: Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
+        // Method invocation verifications
         verify(externalApiService, times(1)).getLatestExchanges("EUR", Optional.of("USD"));
     }
 


### PR DESCRIPTION
- In ExchangeService, the code for checking if an exchange rate is in the catch was extracted into it's own getExchangeRateFromCache() method to simplify the code of the main service methods.
- The same was made with the code for retrieving exchange rates from the External API, which was extracted into the getExchangeRatesFromExternalAPI() method.
- In ConversionService, the code was refactored so that it contacts the cache and the external API via the two previously mentioned methods. This decouples ConversionService from CacheManager and from the ExternalApiService.