### PR TITLE
Adding code for currencyController and related tests

### DIFF
--- a/backend/src/main/java/com/dfc/exchange_api/backend/controllers/CurrencyController.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/controllers/CurrencyController.java
@@ -1,0 +1,42 @@
+package com.dfc.exchange_api.backend.controllers;
+
+import com.dfc.exchange_api.backend.models.Currency;
+import com.dfc.exchange_api.backend.services.CurrencyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+@Tag(name = "4. Currency Controller", description = "Endpoint to retrieve supported currencies, based on the supported currencies of the External API")
+@RestController
+@RequestMapping("/api/v1/currency")
+public class CurrencyController {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CurrencyController.class);
+    private CurrencyService currencyService;
+
+    public CurrencyController(CurrencyService currencyService) {
+        this.currencyService = currencyService;
+    }
+
+    /**
+     * This endpoint returns all the currencies supported by this API. The list of supported currencies is fetched from the list
+     * of supported symbols by the external API at application startup, and is updated via a scheduled job, that runs every hour.
+     * @return the list of supported currencies
+     */
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Valid currency code",
+                    content = @Content),})
+    @Operation(summary = "Get the list of currencies supported by the API")
+    @GetMapping()
+    public ResponseEntity<List<Currency>> getSupportedCurrencies() {
+        LOGGER.info("Received a request on the GET /currency endpoint");
+
+        return ResponseEntity.ok().body(currencyService.getSupportedCurrencies());
+    }
+}

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/CurrencyService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/CurrencyService.java
@@ -79,4 +79,13 @@ public class CurrencyService {
                 LOGGER.info("Could not connext to External API");
             }
     }
+
+    /**
+     * Method used to get all of the currencies supported by this API, called by the REST endpoint associated with this
+     * call.
+     * @return the list of supported currencies
+     */
+    public List<Currency> getSupportedCurrencies(){
+        return currencyRepository.findAll();
+    }
 }

--- a/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_CurrencyController_withMockService_BT_Tests.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_CurrencyController_withMockService_BT_Tests.java
@@ -1,0 +1,63 @@
+package com.dfc.exchange_api.backend.boundaryTests;
+
+
+import com.dfc.exchange_api.backend.controllers.CurrencyController;
+import com.dfc.exchange_api.backend.models.Currency;
+import com.dfc.exchange_api.backend.services.CurrencyService;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = CurrencyController.class)
+class Test_CurrencyController_withMockService_BT_Tests {
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    public CurrencyService currencyService;
+
+    @Test
+    void getSupportedCurrencies_withRepositoryEmpty() throws Exception {
+        // Setting up Expectations
+        when(currencyService.getSupportedCurrencies()).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(
+                        get("/api/v1/currency").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.empty()));
+    }
+
+    @Test
+    void getSupportedCurrencies_withRepositoryFull() throws Exception {
+        // Setting up Expectations
+        Currency dirham = new Currency("United Arab Emirates Dirham", "AED");
+        Currency afghani = new Currency("Afghan Afghani", "AFN");
+        Currency lek = new Currency("Albanian Lek", "ALL");
+        Currency euro = new Currency("Euro", "EUR");
+
+        List<Currency> currenciesOnRepo = Arrays.asList(dirham, afghani, lek, euro);
+        when(currencyService.getSupportedCurrencies()).thenReturn(currenciesOnRepo);
+
+        mockMvc.perform(
+                        get("/api/v1/currency").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.[0].code", is("AED")))
+                .andExpect(jsonPath("$.[1].code", is("AFN")))
+                .andExpect(jsonPath("$.[2].code", is("ALL")))
+                .andExpect(jsonPath("$.[3].code", is("EUR")));
+    }
+}

--- a/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/CurrencyController_IT.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/CurrencyController_IT.java
@@ -1,0 +1,53 @@
+package com.dfc.exchange_api.backend.integrationTests;
+
+import com.dfc.exchange_api.backend.repositories.CurrencyRepository;
+import io.restassured.RestAssured;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import static org.hamcrest.Matchers.*;
+
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase
+public class CurrencyController_IT {
+    private final static String BASE_URL = "http://localhost:";
+
+    @LocalServerPort
+    int randomServerPort;
+
+    @Autowired
+    CurrencyRepository currencyRepository;
+
+    @Test
+    void getSupportedCurrencies_withRepositoryEmpty() throws Exception {
+        // Setting up Expectations
+        currencyRepository.deleteAll();
+
+        RestAssured.given().contentType("application/json")
+                .when()
+                .get(BASE_URL + randomServerPort + "/api/v1/currency")
+                .then()
+                .statusCode(200)
+                .assertThat()
+                .body("$", hasSize(0));
+    }
+
+    @Test
+    void getSupportedCurrencies_withRepositoryFull() throws Exception {
+        // Setting up Expectations
+        RestAssured.given().contentType("application/json")
+                .when()
+                .get(BASE_URL + randomServerPort + "/api/v1/currency")
+                .then()
+                .statusCode(200)
+                .assertThat()
+                .body("$", Matchers.notNullValue()).and()
+                .body("code", hasItems("ANG", "USD", "EUR", "SEK")).and()
+                .body("name", hasItem("Euro"));
+    }
+}

--- a/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/CurrencyService_unitTest.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/CurrencyService_unitTest.java
@@ -15,11 +15,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -55,6 +53,7 @@ class CurrencyService_unitTest {
         dirham = null;
         afghani = null;
         lek = null;
+        euro = null;
     }
 
     @Test
@@ -178,6 +177,30 @@ class CurrencyService_unitTest {
         // Verify that the repository's saveAll method was never called, and that the delete method was called for no longer supported "EUR"
         verify(currencyRepository, never()).saveAll(anyList());
         verify(currencyRepository).deleteAll(List.of(euro));
+    }
 
+    @Test
+    void getSupportedCurrencies_withRepositoryEmpty(){
+        // Setting up Expectations
+        when(currencyRepository.findAll()).thenReturn(Collections.emptyList());
+
+        // Call the method under test
+        assertThat(currencyService.getSupportedCurrencies()).isEmpty();
+
+        // Verify that the repository's saveAll method was called
+        verify(currencyRepository).findAll();
+    }
+
+    @Test
+    void getSupportedCurrencies_withRepositoryFull(){
+        // Setting up Expectations
+        List<Currency> currenciesOnRepo = Arrays.asList(dirham, afghani, lek, euro);
+        when(currencyRepository.findAll()).thenReturn(currenciesOnRepo);
+
+        // Call the method under test
+        assertThat(currencyService.getSupportedCurrencies()).isEqualTo(currenciesOnRepo);
+
+        // Verify that the repository's saveAll method was called
+        verify(currencyRepository).findAll();
     }
 }


### PR DESCRIPTION
- Added a CurrencyController with an endpoint to retrieve all fo the currencies supported by this API.
- Created the underlying CurrencyService method, as well as unit, boundary and integration tests.