### PR TITLE
Small refactors

### DIFF
--- a/backend/src/main/java/com/dfc/exchange_api/backend/controllers/CacheController.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/controllers/CacheController.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
-@Tag(name = "3. Cache Controller", description = "Endpoints to manage and monitor the cache")
+@Tag(name = "4. Cache Controller", description = "Endpoints to manage and monitor the cache")
 @RestController
 @RequestMapping("/api/v1/cache")
 public class CacheController {

--- a/backend/src/main/java/com/dfc/exchange_api/backend/controllers/ConversionController.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/controllers/ConversionController.java
@@ -4,6 +4,7 @@ import com.dfc.exchange_api.backend.exceptions.ExternalApiConnectionError;
 import com.dfc.exchange_api.backend.exceptions.InvalidCurrencyException;
 import com.dfc.exchange_api.backend.services.ConversionService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -11,7 +12,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.PositiveOrZero;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,45 +30,13 @@ public class ConversionController {
     }
 
     /**
-     * This endpoint is used to fetch the conversion from a currency A to a Currency B.
+     * This endpoint fetches the conversion of a specified amount from currency A to a list of currencies. This list can
+     * be composed of either 1 specific currency B, or more currencies, with their codes being separated by commas.
      * @param from - the code of currency A
-     * @param to - the code of currency B
-     * @param amount - the amount to convert
-     * @return A response entity containing a Map with the value of the conversion for the specified currency, and
-     * with HTTP status code OK.
-     * @throws InvalidCurrencyException - In case either the currency A or B are not supported or have an invalid code,
-     * this exception is thrown with HTTP status BAD REQUEST.
-     * @throws ExternalApiConnectionError - In case communication with the External API fails, this exception is thrown
-     * with Http Status BAD GATEWAY.
-     */
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Valid currency codes and amount to convert",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Invalid currency codes or amount supplied",
-                    content = @Content),
-            @ApiResponse(responseCode = "402", description = "Error connecting to external API",
-                    content = @Content),})
-    @Operation(summary = "Get the conversion of a specified amount from currency A to a currency B")
-    @GetMapping("/{from}")
-    public ResponseEntity<Map<String, Double>> getConversionForSpecificCurrency(
-            @PathVariable(name = "from") String from,
-            @RequestParam(name = "to") String to,
-            @RequestParam(name = "amount") @PositiveOrZero(message = "Amount must be non-negative!") Double amount)
-            throws InvalidCurrencyException, ExternalApiConnectionError {
-        LOGGER.info("Received a request on the GET /convert/{from} endpoint");
-
-        return ResponseEntity.ok().body(Map.of(to, conversionService.getConversionForSpecificCurrency(from.toUpperCase(), to.toUpperCase(), amount)));
-    }
-
-    /**
-     * This endpoint is used to fetch the conversion of a specified amount from a currency A to supplied list of
-     * currencies.
-     * @param from - the code of currency A
-     * @param to - the codes of the supplied list of currencies to convert to
+     * @param to - the codes of the specified list of currencies for the conversion, separated by commas
      * @param amount - the amount to be converted
-     * @return A response entity containing a Map with the value of the conversion rate for each supplied currency, and
-     * with HTTP status code OK.
-     * @throws InvalidCurrencyException - In case currency A or one of the supplied currencies is not supported or has an invalid code,
+     * @return a map containing as key the codes of the currencies to be converted to, and as value the value of the conversion
+     * @throws InvalidCurrencyException - In case either the currency A, or the specified currency B are not supported or have an invalid code,
      * this exception is thrown with HTTP status BAD REQUEST.
      * @throws ExternalApiConnectionError - In case communication with the External API fails, this exception is thrown
      * with Http Status BAD GATEWAY.
@@ -80,15 +48,15 @@ public class ConversionController {
                     content = @Content),
             @ApiResponse(responseCode = "402", description = "Error connecting to external API",
                     content = @Content),})
-    @Operation(summary = "Get the conversion of a specified amount from Currency A to a list of supplied currencies")
-    @GetMapping("/{from}/various")
-    public ResponseEntity<Map<String, Double>> getConversionForAll(
-            @PathVariable(name = "from") String from,
-            @RequestParam(name = "to") String to,
-            @RequestParam(name = "amount") @PositiveOrZero(message = "Amount must be non-negative!")  Double amount)
-            throws InvalidCurrencyException, ExternalApiConnectionError{
-        LOGGER.info("Received a request on the GET /convert/{from}/various endpoint");
+    @Operation(summary = "Get the conversion of a specified amount from currency A o a list of specified currencies, separated by commas")
+    @GetMapping
+    public Map<String, Double> getConversionFromCurrency(
+            @Parameter(description = "The code of currency A", required = true) @RequestParam(name = "from") String from,
+            @Parameter(description = "The codes of the specified currencies, separated by commas", required = true) @RequestParam(name = "to") String to,
+            @Parameter(description = "The amount to be converted", required = true) @RequestParam(name = "amount") @PositiveOrZero(message = "Amount must be non-negative!") Double amount)
+            throws InvalidCurrencyException, ExternalApiConnectionError {
+        LOGGER.info("Received a request on the GET /convert endpoint");
 
-        return ResponseEntity.ok().body(conversionService.getConversionForVariousCurrencies(from.toUpperCase(), to.toUpperCase(), amount));
+        return conversionService.getConversionFromCurrency(from.toUpperCase(), to.toUpperCase(), amount);
     }
 }

--- a/backend/src/main/java/com/dfc/exchange_api/backend/controllers/CurrencyController.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/controllers/CurrencyController.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-@Tag(name = "4. Currency Controller", description = "Endpoint to retrieve supported currencies, based on the supported currencies of the External API")
+@Tag(name = "3. Currency Controller", description = "Endpoint to retrieve supported currencies, based on the supported currencies of the External API")
 @RestController
 @RequestMapping("/api/v1/currency")
 public class CurrencyController {

--- a/backend/src/main/java/com/dfc/exchange_api/backend/controllers/ExchangeController.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/controllers/ExchangeController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -51,7 +50,7 @@ public class ExchangeController {
     @GetMapping
     public Map<String, Double> getExchangeRateFromCurrency(
             @Parameter(description = "The code of currency A", required = true) @RequestParam(name = "from") String from,
-            @Parameter(description = "The code of currency B", required = false) @RequestParam(name = "to", required = false) String to)
+            @Parameter(description = "The code of currency B") @RequestParam(name = "to", required = false) String to)
             throws InvalidCurrencyException, ExternalApiConnectionError {
         LOGGER.info("Received a request on the GET /exchange endpoint");
 
@@ -59,12 +58,12 @@ public class ExchangeController {
             // Exchange Rate for a Specific Currency
             LOGGER.info("Request for a specific exchange rate");
 
-            return Map.of(to, exchangeService.getExchangeRateForSpecificCurrency(from, to));
+            return Map.of(to, exchangeService.getExchangeRateForSpecificCurrency(from.toUpperCase(), to.toUpperCase()));
         }else{
             // Exchange Rate for all Currencies
             LOGGER.info("Request for all exchange rates");
 
-            return exchangeService.getExchangeRateForAll(from);
+            return exchangeService.getExchangeRateForAll(from.toUpperCase());
         }
     }
 }

--- a/backend/src/main/java/com/dfc/exchange_api/backend/controllers/ExchangeController.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/controllers/ExchangeController.java
@@ -4,6 +4,7 @@ import com.dfc.exchange_api.backend.exceptions.ExternalApiConnectionError;
 import com.dfc.exchange_api.backend.exceptions.InvalidCurrencyException;
 import com.dfc.exchange_api.backend.services.ExchangeService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
-@Tag(name = "1. Exchange Controller", description = "Endpoints to determine the exchange rate from a given currency")
+@Tag(name = "1. Exchange Controller", description = "Endpoint to determine the exchange rate from a given currency")
 @RestController
 @RequestMapping("/api/v1/exchange")
 public class ExchangeController {
@@ -27,12 +28,14 @@ public class ExchangeController {
     }
 
     /**
-     * This endpoint is used to fetch the exchange rate from a currency A to a Currency B.
+     * This endpoint is used to fetch the exchange rates from a currency A, passed as a required from parameter.
+     * Users can pass an optional "to" parameter - if this is passed, the endpoint will return the exchange rate from currency
+     * A to a specific currency B; otherwise, it will return all the exchange rates from A to all supported currencies.
      * @param from - the code of currency A
-     * @param to - the code of currency B
-     * @return A response entity containing a Map with the value of the conversion rate for the specified currency, and
-     * with HTTP status code OK.
-     * @throws InvalidCurrencyException - In case either the currency A or B are not supported or have an invalid code,
+     * @param to - the optional code of currency B
+     * @return A map with the value of the exchange rate from A to the specified currencies, with their code being the key,
+     * and the value being the exchange rate.
+     * @throws InvalidCurrencyException - In case either the currency A, or the specified currency B are not supported or have an invalid code,
      * this exception is thrown with HTTP status BAD REQUEST.
      * @throws ExternalApiConnectionError - In case communication with the External API fails, this exception is thrown
      * with Http Status BAD GATEWAY.
@@ -44,41 +47,24 @@ public class ExchangeController {
                     content = @Content),
             @ApiResponse(responseCode = "402", description = "Error connecting to external API",
                     content = @Content),})
-    @Operation(summary = "Get the exchange rates from currency A to a currency B")
-    @GetMapping("/{from}")
-    public ResponseEntity<Map<String, Double>> getExchangeRateForSpecificCurrency(
-            @PathVariable(name = "from") String from,
-            @RequestParam(name = "to") String to)
+    @Operation(summary = "Get the exchange rates from currency A to either a currency B, if \"to\" is present, or all supported currencies, if \"to\" is absent")
+    @GetMapping
+    public Map<String, Double> getExchangeRateFromCurrency(
+            @Parameter(description = "The code of currency A", required = true) @RequestParam(name = "from") String from,
+            @Parameter(description = "The code of currency B", required = false) @RequestParam(name = "to", required = false) String to)
             throws InvalidCurrencyException, ExternalApiConnectionError {
-        LOGGER.info("Received a request on the GET /exchange/{currency} endpoint");
+        LOGGER.info("Received a request on the GET /exchange endpoint");
 
-        return ResponseEntity.ok().body(Map.of(to, exchangeService.getExchangeRateForSpecificCurrency(from.toUpperCase(), to.toUpperCase())));
-    }
+        if(to != null){
+            // Exchange Rate for a Specific Currency
+            LOGGER.info("Request for a specific exchange rate");
 
-    /**
-     * This endpoint is used to fetch the exchange rate from a currency A to all the supported currencies.
-     * @param code - the code of currency A
-     * @return A response entity containing a Map with the value of the conversion rate for each supported currency, and
-     * with HTTP status code OK.
-     * @throws InvalidCurrencyException - In case currency A is not supported or has an invalid code,
-     * this exception is thrown with HTTP status BAD REQUEST.
-     * @throws ExternalApiConnectionError - In case communication with the External API fails, this exception is thrown
-     * with Http Status BAD GATEWAY.
-     */
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Valid currency code",
-                    content = @Content),
-            @ApiResponse(responseCode = "400", description = "Invalid currency code supplied",
-                    content = @Content),
-            @ApiResponse(responseCode = "402", description = "Error connecting to external API",
-                    content = @Content),})
-    @Operation(summary = "Get the exchange rates from a currency to all other supported currencies")
-    @GetMapping("/{from}/all")
-    public ResponseEntity<Map<String, Double>> getExchangeRateForAll(
-            @PathVariable(name = "from") String code)
-            throws InvalidCurrencyException, ExternalApiConnectionError{
-        LOGGER.info("Received a request on the GET /exchange/{currency}/all endpoint");
+            return Map.of(to, exchangeService.getExchangeRateForSpecificCurrency(from, to));
+        }else{
+            // Exchange Rate for all Currencies
+            LOGGER.info("Request for all exchange rates");
 
-        return ResponseEntity.ok().body(exchangeService.getExchangeRateForAll(code.toUpperCase()));
+            return exchangeService.getExchangeRateForAll(from);
+        }
     }
 }

--- a/backend/src/main/java/com/dfc/exchange_api/backend/exceptions/RestExceptionHandler.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/exceptions/RestExceptionHandler.java
@@ -22,8 +22,8 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(ExternalApiConnectionError.class)
-    protected ResponseEntity<Object> handleIncorrectParameter(ExternalApiConnectionError ex){
-        ErrorDetails apiError = new ErrorDetails(HttpStatus.BAD_GATEWAY);
+    protected ResponseEntity<Object> handleExternalAPIError(ExternalApiConnectionError ex){
+        ErrorDetails apiError = new ErrorDetails(HttpStatus.SERVICE_UNAVAILABLE);
         apiError.setMessage(ex.getMessage());
         apiError.setTimestamp(LocalDateTime.now());
         return buildResponseEntity(apiError);
@@ -46,7 +46,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(CacheNotFoundException.class)
-    protected ResponseEntity<Object> handleConstraintViolationException(CacheNotFoundException ex) {
+    protected ResponseEntity<Object> handleCacheError(CacheNotFoundException ex) {
         ErrorDetails apiError = new ErrorDetails(HttpStatus.NOT_FOUND);
         apiError.setMessage(ex.getMessage());
         apiError.setTimestamp(LocalDateTime.now());

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/CacheService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/CacheService.java
@@ -3,6 +3,7 @@ package com.dfc.exchange_api.backend.services;
 import com.dfc.exchange_api.backend.exceptions.CacheNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCache;
@@ -15,9 +16,10 @@ import java.util.Map;
 
 @Service
 public class CacheService {
+    @Value("${cache.name}")
+    private String CACHE_NAME;
     private static final Logger LOGGER = LoggerFactory.getLogger(CacheService.class);
     private static final String INPUT_REGEX = "[\n\r]";
-    private static final String CACHE_NAME = "exchangeRate";
     private CacheManager cacheManager;
 
     public CacheService(CacheManager cacheManager) {

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ConversionService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ConversionService.java
@@ -8,11 +8,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class ConversionService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConversionService.class);
-    private static final String INPUT_REGEX = "[\n\r]";
     private CurrencyRepository currencyRepository;
     private CurrencyService currencyService;
     private ExchangeService exchangeService;
@@ -24,64 +24,28 @@ public class ConversionService {
     }
 
     /**
-     * This method returns the conversion value of a specified amount from a Currency A to another Currency B.
-     * To do so, one of 2 executions path can happen:
+     * This method returns the conversion value of a specified amount from a Currency A to a list of Currencies B desired by the user.
+     * To do so, one of 2 executions path can happen for each of the currencies in list B:
      *      1. We will fetch the exchange rate of A -> B from the exchangeRate cache,
      *          in case it's stored there. We then calculate the conversion based on this rate.
      *      2. If the exchanged rate of A -> B is not in the exchangeRate cache, we will fetch it from the external API, do the
      *          conversion calculation, and store the fetched rate in its cache.
-     * @param fromCode - the code of Currency A
-     * @param toCode - the code of Currency B
-     * @param amount - the amount to be converted
-     * @return the value of the conversion
-     * @throws InvalidCurrencyException - if either of the currency codes passed as parameters by the user is not supported
-     *      * by the API, throws this exception with the HTTP Status BAD REQUEST
-     * @throws ExternalApiConnectionError - in case of an error in the connection to the External API
-     */
-    public Double getConversionForSpecificCurrency(String fromCode, String toCode, Double amount) throws InvalidCurrencyException, ExternalApiConnectionError {
-        // Verifying if the passed currencies are supported by the service
-        if (!this.checkIfCurrencyExists(fromCode) || !this.checkIfCurrencyExists(toCode)) {
-            LOGGER.info("One of the passed currencies is not supported by the service!");
-            throw new InvalidCurrencyException("Invalid currency code(s) provided!");
-        }
-
-        // Checking if exchange rate is in the Cache
-        Double exchangeRate = exchangeService.getExchangeRateFromCache(fromCode, toCode);
-
-        if(exchangeRate == null){
-            // Not in cache - needs to be fetched from the External API
-            LOGGER.info("The exchange rate for {} is not in the cache", toCode.replaceAll(INPUT_REGEX, "_"));
-
-            exchangeRate = exchangeService.getExchangeRatesFromExternalAPI(fromCode, toCode).get(toCode);
-        }else{
-            LOGGER.info("The exchange rate for {} is fetched from the cache", toCode.replaceAll(INPUT_REGEX, "_"));
-        }
-
-        // Calculating the conversion rates
-        LOGGER.info("Finalizing processing the call to /convert/{from} endpoint with parameters: from - {}; to - {}", fromCode.replaceAll(INPUT_REGEX, "_"), toCode.replaceAll(INPUT_REGEX,"_"));
-        return exchangeRate*amount;
-    }
-
-
-    /**
-     * This method returns the conversion value of a specified amount from a Currency A to a list of Currencies B desired by the user.
-     * To do so, one of 2 executions path can happen for each of the currencies in list B:
-     *      1. If it's not in the conversionValue cache, we will fetch the exchange rate of A -> B from the exchangeRate cache,
-     *          in case it's stored there. We then calculate the conversion based on this rate.
-     *      2. If the exchanged rate of A -> B is not in the exchangeRate cache, we will fetch it from the external API, do the
-     *          conversion calculation, and store the fetched rate in its cache.
      * @param fromCode - the fromCode of Currency A
-     * @param toCurrencies - the list of supplied currencies to convert to
+     * @param toCurrencies - the list of supplied currencies to convert to, separated by commas
      * @param amount - the desired amount to be converted
      * @return a Map<String, Double> containing the conversion value for each supported currency (with their code being
      * the key of the map)
      * @throws InvalidCurrencyException - thrown when the user has passed an invalid code, with an HTTP Status BAD REQUEST
      * @throws ExternalApiConnectionError - in case of an error in the connection to the External API
      */
-    public Map<String, Double> getConversionForVariousCurrencies(String fromCode, String toCurrencies, Double amount) throws InvalidCurrencyException, ExternalApiConnectionError {
+    public Map<String, Double> getConversionFromCurrency(String fromCode, String toCurrencies, Double amount) throws InvalidCurrencyException, ExternalApiConnectionError {
         // Verifying if the currencies are supported by the service
-        List<String> currencyToConvertCodes = new ArrayList<>(Arrays.asList(toCurrencies.split(",")));
-        currencyToConvertCodes.add(fromCode);  // TO make verification easier
+        if (!this.checkIfCurrencyExists(fromCode)) {
+            LOGGER.info("The passed currency is not supported by the service!");
+            throw new InvalidCurrencyException("Invalid currency code " + fromCode + " provided!");
+        }
+
+        List<String> currencyToConvertCodes = Arrays.asList(toCurrencies.split(","));
 
         currencyToConvertCodes.forEach(x -> {
                 if (!this.checkIfCurrencyExists(x)) {
@@ -91,13 +55,20 @@ public class ConversionService {
             }
         );
 
-        currencyToConvertCodes.remove(fromCode);  // No need to convert to own currency
-
         // The currencies are verified
         Map<String, Double> conversionValue = new HashMap<>();
-
         StringBuilder symbolsBuilder = new StringBuilder();                 // Will store symbols of currencies to be fetched from External API
         String symbols;                                                     // Will store the result of the StringBuilder
+
+        // Edge case -> amount == 0
+        if(amount == 0.0){
+            return currencyToConvertCodes.stream().collect(
+                    Collectors.toMap(
+                            currency -> currency,
+                            currency -> 0.0
+                    )
+            );
+        }
 
         // Checking if the passed Currencies exchange rate is in the cache or not; If not, contacting the External API
         currencyToConvertCodes.forEach(supportedCurrency -> {
@@ -132,7 +103,7 @@ public class ConversionService {
     }
 
     /**
-     * Auxilliary method that checks if a code passed as a parameter by the user in an API request belongs to a supported
+     * Auxiliary method that checks if a code passed as a parameter by the user in an API request belongs to a supported
      * currency or not.
      * @param code - the code of the Currency to be checked
      * @return a boolean representing whether the code is supported or not by the API

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ConversionService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ConversionService.java
@@ -98,7 +98,7 @@ public class ConversionService {
         fetchedExchangeRates.entrySet().forEach(entry -> entry.setValue(entry.getValue() * amount));
         conversionValue.putAll(fetchedExchangeRates);
 
-        LOGGER.info("Finalizing processing the call to /exchange/{currency}/all endpoint with parameters: fromCode - {}", fromCode);
+        LOGGER.info("Finalizing processing the call to /exchange/{currency}/all endpoint with parameters: fromCode - {}", fromCode.replaceAll("[\n\r]", "_"));
         return conversionValue;
     }
 

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
@@ -110,7 +110,7 @@ public class ExchangeService {
         // Fetching from external API
         exchangeRates.putAll(this.getExchangeRatesFromExternalAPI(fromCode, symbols));
 
-        LOGGER.info("Finalizing processing the call to /exchange/{from}/all endpoint with parameters: fromCode - {}", fromCode);
+        LOGGER.info("Finalizing processing the call to /exchange/{from}/all endpoint with parameters: fromCode - {}", fromCode.replaceAll(INPUT_REGEX, "_"));
         return exchangeRates;
     }
 

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
@@ -182,7 +182,7 @@ public class ExchangeService {
     }
 
     /**
-     * Auxilliary method that checks if a code passed as a parameter by the user in an API request belongs to a supported
+     * Auxiliary method that checks if a code passed as a parameter by the user in an API request belongs to a supported
      * currency or not.
      * @param code - the code of the Currency to be checked
      * @return a boolean representing whether the code is supported or not by the API

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ExchangeService.java
@@ -7,6 +7,7 @@ import com.dfc.exchange_api.backend.repositories.CurrencyRepository;
 import com.google.gson.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
@@ -18,6 +19,8 @@ import java.util.Optional;
 
 @Service
 public class ExchangeService {
+    @Value("${cache.name}")
+    private String CACHE_NAME;
     private static final Logger LOGGER = LoggerFactory.getLogger(ExchangeService.class);
     private static final String INPUT_REGEX = "[\n\r]";
     private ExternalApiService apiService;
@@ -119,7 +122,7 @@ public class ExchangeService {
      * @return the exchange rate stored in the cache; or null, in case there isn't any value in the cache
      */
     public Double getExchangeRateFromCache(String fromCode, String toCode) {
-        Cache exchangeRateCache = cacheManager.getCache("exchangeRate");
+        Cache exchangeRateCache = cacheManager.getCache(CACHE_NAME);
 
         if(exchangeRateCache != null){
             // Create the cache key
@@ -153,7 +156,7 @@ public class ExchangeService {
         LOGGER.info("Fetching from external API the required exchange rates from {}", fromCode.replaceAll(INPUT_REGEX, "_"));
 
         Map<String, Double> exchangeRates = new HashMap<>();
-        Cache exchangeRateCache = cacheManager.getCache("exchangeRate");
+        Cache exchangeRateCache = cacheManager.getCache(CACHE_NAME);
         JsonObject rates = apiService.getLatestExchanges(fromCode, Optional.of(symbols)).getAsJsonObject();
 
         for(String key: rates.keySet()){

--- a/backend/src/main/java/com/dfc/exchange_api/backend/services/ExternalApiService.java
+++ b/backend/src/main/java/com/dfc/exchange_api/backend/services/ExternalApiService.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
@@ -23,9 +24,10 @@ import java.util.concurrent.TimeoutException;
  */
 @Service
 public class ExternalApiService {
+    @Value("${external.api.base.url}")
+    private String BASE_URL = "https://api.exchangerate.host";
     private static final Logger LOGGER = LoggerFactory.getLogger(ExternalApiService.class);
     private final RestTemplate restTemplate;
-    private static final String BASE_URL = "https://api.exchangerate.host";
 
     public ExternalApiService(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -14,3 +14,9 @@ spring.jpa.hibernate.ddl-auto=create
 spring.datasource.username=admin
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+# Defining BASE_URL for external API call
+external.api.base.url = https://api.exchangerate.host
+
+# DEfining cache name
+cache.name = exchangeRates

--- a/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ConversionController_withMockService_BT_Tests.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ConversionController_withMockService_BT_Tests.java
@@ -35,10 +35,11 @@ class Test_ConversionController_withMockService_BT_Tests {
         returnedExchanges.put("GIP", 42.759);
         returnedExchanges.put("ANG", 98.0237);
 
-        when(conversionService.getConversionForVariousCurrencies("EUR", "USD,GIP,ANG", 50.0)).thenReturn(returnedExchanges);
+        when(conversionService.getConversionFromCurrency("EUR", "USD,GIP,ANG", 50.0)).thenReturn(returnedExchanges);
 
         mockMvc.perform(
-                        get("/api/v1/convert/EUR/various")
+                        get("/api/v1/convert")
+                                .param("from", "EUR")
                                 .param("to", "USD,GIP,ANG")
                                 .param("amount", "50.0").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -49,10 +50,11 @@ class Test_ConversionController_withMockService_BT_Tests {
 
     @Test
     void whenGettingConversionForMany_withValidInput_externalAPIFailure_thenThrowException() throws Exception {
-        when(conversionService.getConversionForVariousCurrencies("EUR", "USD,GIP,ANG", 50.0)).thenThrow(ExternalApiConnectionError.class);
+        when(conversionService.getConversionFromCurrency("EUR", "USD,GIP,ANG", 50.0)).thenThrow(ExternalApiConnectionError.class);
 
         mockMvc.perform(
-                        get("/api/v1/convert/EUR/various")
+                        get("/api/v1/convert")
+                                .param("from", "EUR")
                                 .param("to", "USD,GIP,ANG")
                                 .param("amount", "50.0")
                                 .contentType(MediaType.APPLICATION_JSON))
@@ -61,10 +63,11 @@ class Test_ConversionController_withMockService_BT_Tests {
 
     @Test
     void whenGettingConversionForMany_withInvalidFromInput_thenThrowException() throws Exception {
-        when(conversionService.getConversionForVariousCurrencies("ZZZ", "USD,GIP,ANG", 50.0)).thenThrow(InvalidCurrencyException.class);
+        when(conversionService.getConversionFromCurrency("ZZZ", "USD,GIP,ANG", 50.0)).thenThrow(InvalidCurrencyException.class);
 
         mockMvc.perform(
-                        get("/api/v1/convert/ZZZ/various")
+                        get("/api/v1/convert")
+                                .param("from", "ZZZ")
                                 .param("to", "USD,GIP,ANG")
                                 .param("amount", "50.0")
                                 .contentType(MediaType.APPLICATION_JSON))
@@ -73,10 +76,11 @@ class Test_ConversionController_withMockService_BT_Tests {
 
     @Test
     void whenGettingConversionForMany_withInvalidToInput_thenThrowException() throws Exception {
-        when(conversionService.getConversionForVariousCurrencies("USD", "ZZZ,GIP,ANG", 50.0)).thenThrow(InvalidCurrencyException.class);
+        when(conversionService.getConversionFromCurrency("USD", "ZZZ,GIP,ANG", 50.0)).thenThrow(InvalidCurrencyException.class);
 
         mockMvc.perform(
-                        get("/api/v1/convert/USD/various")
+                        get("/api/v1/convert")
+                                .param("from", "USD")
                                 .param("to", "ZZZ,GIP,ANG")
                                 .param("amount", "50.0")
                                 .contentType(MediaType.APPLICATION_JSON))
@@ -86,7 +90,8 @@ class Test_ConversionController_withMockService_BT_Tests {
     @Test
     void whenGettingConversionForMany_withInvalidAmountInput_thenThrowException() throws Exception {
         mockMvc.perform(
-                        get("/api/v1/convert/EUR/various")
+                        get("/api/v1/convert")
+                                .param("from", "EUR")
                                 .param("to", "USD,GIP,ANG")
                                 .param("amount", "-50.0")
                                 .contentType(MediaType.APPLICATION_JSON))
@@ -95,10 +100,14 @@ class Test_ConversionController_withMockService_BT_Tests {
 
     @Test
     void whenGettingConversionForSpecificCurrency_withValidInput_thenReturnOK() throws Exception {
-        when(conversionService.getConversionForSpecificCurrency("EUR", "USD", 50.0)).thenReturn(54.4212);
+        Map<String, Double> returnedConversions = new HashMap<>();
+        returnedConversions.put("USD", 54.4212);
+
+        when(conversionService.getConversionFromCurrency("EUR", "USD", 50.0)).thenReturn(returnedConversions);
 
         mockMvc.perform(
-                        get("/api/v1/convert/EUR")
+                        get("/api/v1/convert")
+                                .param("from", "EUR")
                                 .param("to", "USD")
                                 .param("amount", "50.0").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -107,10 +116,11 @@ class Test_ConversionController_withMockService_BT_Tests {
 
     @Test
     void whenGettingConversionForSpecificCurrency_withValidInput_externalAPIFailure_thenThrowException() throws Exception {
-        when(conversionService.getConversionForSpecificCurrency("EUR", "USD", 50.0)).thenThrow(ExternalApiConnectionError.class);
+        when(conversionService.getConversionFromCurrency("EUR", "USD", 50.0)).thenThrow(ExternalApiConnectionError.class);
 
         mockMvc.perform(
-                        get("/api/v1/convert/EUR")
+                        get("/api/v1/convert")
+                                .param("from", "EUR")
                                 .param("to", "USD")
                                 .param("amount", "50.0").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadGateway());
@@ -118,10 +128,11 @@ class Test_ConversionController_withMockService_BT_Tests {
 
     @Test
     void whenGettingConversionForSpecificCurrency_withInvalidFromInput_thenThrowException() throws Exception {
-        when(conversionService.getConversionForSpecificCurrency("ZZZ", "USD", 50.0)).thenThrow(InvalidCurrencyException.class);
+        when(conversionService.getConversionFromCurrency("ZZZ", "USD", 50.0)).thenThrow(InvalidCurrencyException.class);
 
         mockMvc.perform(
-                        get("/api/v1/convert/ZZZ")
+                        get("/api/v1/convert")
+                                .param("from", "ZZZ")
                                 .param("to", "USD")
                                 .param("amount", "50.0").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
@@ -129,10 +140,11 @@ class Test_ConversionController_withMockService_BT_Tests {
 
     @Test
     void whenGettingConversionForSpecificCurrency_withInvalidToInput_thenThrowException() throws Exception {
-        when(conversionService.getConversionForSpecificCurrency("USD", "ZZZ", 50.0)).thenThrow(InvalidCurrencyException.class);
+        when(conversionService.getConversionFromCurrency("USD", "ZZZ", 50.0)).thenThrow(InvalidCurrencyException.class);
 
         mockMvc.perform(
-                        get("/api/v1/convert/USD")
+                        get("/api/v1/convert")
+                                .param("from", "USD")
                                 .param("to", "ZZZ")
                                 .param("amount", "50.0").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
@@ -141,7 +153,8 @@ class Test_ConversionController_withMockService_BT_Tests {
     @Test
     void whenGettingConversionForSpecificCurrency_withInvalidAmountInput_thenThrowException() throws Exception {
         mockMvc.perform(
-                        get("/api/v1/convert/EUR")
+                        get("/api/v1/convert")
+                                .param("from", "EUR")
                                 .param("to", "USD")
                                 .param("amount", String.valueOf(-50.0))
                                 .contentType(MediaType.APPLICATION_JSON))

--- a/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ConversionController_withMockService_BT_Tests.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ConversionController_withMockService_BT_Tests.java
@@ -58,7 +58,7 @@ class Test_ConversionController_withMockService_BT_Tests {
                                 .param("to", "USD,GIP,ANG")
                                 .param("amount", "50.0")
                                 .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadGateway());
+                .andExpect(status().isServiceUnavailable());
     }
 
     @Test
@@ -123,7 +123,7 @@ class Test_ConversionController_withMockService_BT_Tests {
                                 .param("from", "EUR")
                                 .param("to", "USD")
                                 .param("amount", "50.0").contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadGateway());
+                .andExpect(status().isServiceUnavailable());
     }
 
     @Test

--- a/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ExchangeController_withMockService_BT_Tests.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ExchangeController_withMockService_BT_Tests.java
@@ -38,7 +38,8 @@ class Test_ExchangeController_withMockService_BT_Tests {
         when(exchangeService.getExchangeRateForAll("EUR")).thenReturn(returnedExchanges);
 
         mockMvc.perform(
-                        get("/api/v1/exchange/EUR/all").contentType(MediaType.APPLICATION_JSON))
+                        get("/api/v1/exchange")
+                                .param("from", "EUR").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.USD", is(1.088424)))
                 .andExpect(jsonPath("$.GIP", is(0.85518)))
@@ -50,7 +51,8 @@ class Test_ExchangeController_withMockService_BT_Tests {
         when(exchangeService.getExchangeRateForAll("EUR")).thenThrow(ExternalApiConnectionError.class);
 
         mockMvc.perform(
-                        get("/api/v1/exchange/EUR/all").contentType(MediaType.APPLICATION_JSON))
+                        get("/api/v1/exchange")
+                                .param("from", "EUR").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadGateway());
     }
 
@@ -59,7 +61,8 @@ class Test_ExchangeController_withMockService_BT_Tests {
         when(exchangeService.getExchangeRateForAll("ZZZ")).thenThrow(InvalidCurrencyException.class);
 
         mockMvc.perform(
-                        get("/api/v1/exchange/ZZZ/all").contentType(MediaType.APPLICATION_JSON))
+                        get("/api/v1/exchange")
+                                .param("from", "ZZZ").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }
 
@@ -68,7 +71,8 @@ class Test_ExchangeController_withMockService_BT_Tests {
         when(exchangeService.getExchangeRateForSpecificCurrency("EUR", "USD")).thenReturn(1.088424);
 
         mockMvc.perform(
-                        get("/api/v1/exchange/EUR")
+                        get("/api/v1/exchange")
+                                .param("from", "EUR")
                                 .param("to", "USD").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.USD", is(1.088424)));
@@ -79,7 +83,8 @@ class Test_ExchangeController_withMockService_BT_Tests {
         when(exchangeService.getExchangeRateForSpecificCurrency("EUR", "USD")).thenThrow(ExternalApiConnectionError.class);
 
         mockMvc.perform(
-                        get("/api/v1/exchange/EUR")
+                        get("/api/v1/exchange")
+                                .param("from", "EUR")
                                 .param("to", "USD").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadGateway());
     }
@@ -89,7 +94,8 @@ class Test_ExchangeController_withMockService_BT_Tests {
         when(exchangeService.getExchangeRateForSpecificCurrency("ZZZ", "USD")).thenThrow(InvalidCurrencyException.class);
 
         mockMvc.perform(
-                        get("/api/v1/exchange/ZZZ")
+                        get("/api/v1/exchange")
+                                .param("from", "ZZZ")
                                 .param("to", "USD").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }
@@ -99,7 +105,8 @@ class Test_ExchangeController_withMockService_BT_Tests {
         when(exchangeService.getExchangeRateForSpecificCurrency("EUR", "ZZZ")).thenThrow(InvalidCurrencyException.class);
 
         mockMvc.perform(
-                        get("/api/v1/exchange/EUR")
+                        get("/api/v1/exchange")
+                                .param("from", "EUR")
                                 .param("to", "ZZZ").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }

--- a/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ExchangeController_withMockService_BT_Tests.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/boundaryTests/Test_ExchangeController_withMockService_BT_Tests.java
@@ -53,7 +53,7 @@ class Test_ExchangeController_withMockService_BT_Tests {
         mockMvc.perform(
                         get("/api/v1/exchange")
                                 .param("from", "EUR").contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadGateway());
+                .andExpect(status().isServiceUnavailable());
     }
 
     @Test
@@ -86,7 +86,7 @@ class Test_ExchangeController_withMockService_BT_Tests {
                         get("/api/v1/exchange")
                                 .param("from", "EUR")
                                 .param("to", "USD").contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadGateway());
+                .andExpect(status().isServiceUnavailable());
     }
 
     @Test

--- a/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/CacheController_IT.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/CacheController_IT.java
@@ -3,6 +3,7 @@ package com.dfc.exchange_api.backend.integrationTests;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -22,6 +23,8 @@ class CacheController_IT {
     @Autowired
     CacheManager cacheManager;
 
+    @Value("${cache.name}")
+    private String CACHE_NAME;
     private Cache exchangeRateCache;
 
     @LocalServerPort
@@ -29,7 +32,7 @@ class CacheController_IT {
 
     @BeforeEach
     void setUp(){
-        this.exchangeRateCache = cacheManager.getCache("exchangeRate");
+        this.exchangeRateCache = cacheManager.getCache(CACHE_NAME);
     }
 
     @AfterEach

--- a/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/ConversionController_IT.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/ConversionController_IT.java
@@ -43,8 +43,9 @@ class ConversionController_IT {
     @Test
     void whenGettingConversionForVarious_withValidInput_NotInCache_thenContactExternalAPI() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR", "to", "USD,GBP", "amount", "50.0")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/convert/EUR/various?to=USD,GBP&amount=50.0")
+                .get(BASE_URL + randomServerPort + "/api/v1/convert")
                 .then()
                 .statusCode(200)
                 .assertThat()
@@ -61,8 +62,9 @@ class ConversionController_IT {
         this.exchangeRateCache.put("EUR_USD", 100.88186);
 
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR", "to", "USD,GBP", "amount", "50.0")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/convert/EUR/various?to=USD,GBP&amount=50.0")
+                .get(BASE_URL + randomServerPort + "/api/v1/convert")
                 .then()
                 .statusCode(200)
                 .assertThat()
@@ -74,8 +76,9 @@ class ConversionController_IT {
     @Test
     void whenGettingConversionForVarious_withInvalidFromInput_thenThrowException() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "ZZZ", "to", "USD,GBP", "amount", "50.0")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/convert/ZZZ/various?to=USD,GBP&amount=50.0")
+                .get(BASE_URL + randomServerPort + "/api/v1/convert")
                 .then()
                 .statusCode(400)
                 .body("message", equalTo("Invalid currency code ZZZ provided!"));
@@ -84,8 +87,9 @@ class ConversionController_IT {
     @Test
     void whenGettingConversionForVarious_withInvalidToInput_thenThrowException() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR", "to", "USD,ZZZ", "amount", "50.0")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/convert/EUR/various?to=USD,ZZZ&amount=50.0")
+                .get(BASE_URL + randomServerPort + "/api/v1/convert")
                 .then()
                 .statusCode(400)
                 .body("message", equalTo("Invalid currency code ZZZ provided!"));
@@ -94,8 +98,9 @@ class ConversionController_IT {
     @Test
     void whenGettingConversionForVarious_withInvalidAmountInput_thenThrowException() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "ZZZ", "to", "USD,GBP", "amount", "-50.0")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/convert/EUR/various?to=USD,GBP&amount=-50.0")
+                .get(BASE_URL + randomServerPort + "/api/v1/convert")
                 .then()
                 .statusCode(400);
     }
@@ -103,8 +108,9 @@ class ConversionController_IT {
     @Test
     void whenGettingConversionForSpecificCurrency_withValidInput_NotInCache_thenContactExternalAPI() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR", "to", "USD", "amount", "50.0")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/convert/EUR?to=USD&amount=60.0")
+                .get(BASE_URL + randomServerPort + "/api/v1/convert")
                 .then()
                 .statusCode(200)
                 .assertThat()
@@ -119,8 +125,9 @@ class ConversionController_IT {
         this.exchangeRateCache.put("EUR_USD", 100.88186);
 
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR", "to", "USD", "amount", "50.0")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/convert/EUR?to=USD&amount=50.0")
+                .get(BASE_URL + randomServerPort + "/api/v1/convert")
                 .then()
                 .statusCode(200)
                 .assertThat()
@@ -132,8 +139,9 @@ class ConversionController_IT {
     @Test
     void whenGettingConversionForSpecificCurrency_withInvalidFromInput_thenThrowException() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "ZZZ", "to", "USD", "amount", "50.0")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/convert/ZZZ?to=USD")
+                .get(BASE_URL + randomServerPort + "/api/v1/convert")
                 .then()
                 .statusCode(400);
     }
@@ -141,8 +149,9 @@ class ConversionController_IT {
     @Test
     void whenGettingConversionForSpecificCurrency_withInvalidToInput_thenThrowException() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR", "to", "ZZZ", "amount", "50.0")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/convert/EUR?to=ZZZ")
+                .get(BASE_URL + randomServerPort + "/api/v1/convert")
                 .then()
                 .statusCode(400);
     }
@@ -150,8 +159,9 @@ class ConversionController_IT {
     @Test
     void whenGettingConversionForSpecificCurrency_withInvalidAmountInput_thenThrowException() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR", "to", "USD", "amount", "-50.0")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/convert/EUR?to=USD&amount=-50.0")
+                .get(BASE_URL + randomServerPort + "/api/v1/convert")
                 .then()
                 .statusCode(400);
     }

--- a/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/ConversionController_IT.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/ConversionController_IT.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -27,11 +28,13 @@ class ConversionController_IT {
     @Autowired
     CacheManager cacheManager;
 
+    @Value("${cache.name}")
+    private String CACHE_NAME;
     private Cache exchangeRateCache;
 
     @BeforeEach
     void setUp(){
-        this.exchangeRateCache = cacheManager.getCache("exchangeRate");
+        this.exchangeRateCache = cacheManager.getCache(CACHE_NAME);
     }
 
     @AfterEach

--- a/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/ExchangeController_IT.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/ExchangeController_IT.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -22,6 +23,8 @@ class ExchangeController_IT {
     @Autowired
     CacheManager cacheManager;
 
+    @Value("${cache.name}")
+    private String CACHE_NAME;
     private Cache exchangeRateCache;
 
     @LocalServerPort
@@ -29,7 +32,7 @@ class ExchangeController_IT {
 
     @BeforeEach
     void setUp(){
-        this.exchangeRateCache = cacheManager.getCache("exchangeRate");
+        this.exchangeRateCache = cacheManager.getCache(CACHE_NAME);
     }
 
     @AfterEach
@@ -97,7 +100,8 @@ class ExchangeController_IT {
 
     @Test
     void whenGettingExchangeRateForSpecificCurrency_withValidInput_InCache_thenSearchInCache() {
-        this.exchangeRateCache.put("EUR_USD", 101010.2);
+        this.exchangeRateCache.clear();
+        this.exchangeRateCache.put("EUR_USD", 1.086982);
 
         RestAssured.given().contentType("application/json")
                 .queryParams("from", "EUR", "to", "USD")
@@ -107,7 +111,7 @@ class ExchangeController_IT {
                 .statusCode(200)
                 .assertThat()
                 .body("$", hasKey("USD")).and()
-                .body("USD", equalTo(101010.2f));
+                .body("USD", equalTo(1.086982f));
     }
 
 

--- a/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/ExchangeController_IT.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/integrationTests/ExchangeController_IT.java
@@ -41,8 +41,9 @@ class ExchangeController_IT {
     @Test
     void whenGettingExchangeRateForAll_withValidInput_NotInCache_thenContactExternalAPI() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/exchange/EUR/all")
+                .get(BASE_URL + randomServerPort + "/api/v1/exchange")
                 .then()
                 .statusCode(200)
                 .assertThat()
@@ -58,8 +59,9 @@ class ExchangeController_IT {
         this.exchangeRateCache.put("EUR_USD", 101010.2);
 
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/exchange/EUR/all")
+                .get(BASE_URL + randomServerPort + "/api/v1/exchange")
                 .then()
                 .statusCode(200)
                 .assertThat()
@@ -71,8 +73,9 @@ class ExchangeController_IT {
     @Test
     void whenGettingExchangeRateForAll_withInvalidInput_thenThrowException() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "ZZZ")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/exchange/ZZZ/all")
+                .get(BASE_URL + randomServerPort + "/api/v1/exchange")
                 .then()
                 .statusCode(400);
     }
@@ -80,8 +83,9 @@ class ExchangeController_IT {
     @Test
     void whenGettingExchangeRateForSpecificCurrency_withValidInput_NotInCache_thenContactExternalAPI() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR", "to", "USD")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/exchange/EUR?to=USD")
+                .get(BASE_URL + randomServerPort + "/api/v1/exchange")
                 .then()
                 .statusCode(200)
                 .assertThat()
@@ -96,8 +100,9 @@ class ExchangeController_IT {
         this.exchangeRateCache.put("EUR_USD", 101010.2);
 
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR", "to", "USD")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/exchange/EUR?to=USD")
+                .get(BASE_URL + randomServerPort + "/api/v1/exchange")
                 .then()
                 .statusCode(200)
                 .assertThat()
@@ -109,8 +114,9 @@ class ExchangeController_IT {
     @Test
     void whenGettingExchangeRateForSpecificCurrency_withInvalidFromInput_thenThrowException() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "ZZZ", "to", "USD")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/exchange/ZZZ?to=USD")
+                .get(BASE_URL + randomServerPort + "/api/v1/exchange")
                 .then()
                 .statusCode(400);
     }
@@ -118,8 +124,9 @@ class ExchangeController_IT {
     @Test
     void whenGettingExchangeRateForSpecificCurrency_withInvalidToInput_thenThrowException() {
         RestAssured.given().contentType("application/json")
+                .queryParams("from", "EUR", "to", "ZZZ")
                 .when()
-                .get(BASE_URL + randomServerPort + "/api/v1/exchange/EUR?to=ZZZ")
+                .get(BASE_URL + randomServerPort + "/api/v1/exchange")
                 .then()
                 .statusCode(400);
     }

--- a/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/CacheService_unitTest.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/CacheService_unitTest.java
@@ -37,7 +37,7 @@ class CacheService_unitTest {
     @Test
     void whenCacheEmpty_getAllEntries_returnEmpty(){
         // Set up Expectations
-        when(cacheManager.getCache("exchangeRate")).thenReturn(caffeineCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(caffeineCache);
 
         com.github.benmanes.caffeine.cache.Cache nativeCache = mock(com.github.benmanes.caffeine.cache.Cache.class);
 
@@ -56,7 +56,7 @@ class CacheService_unitTest {
         concurrentMap.put("EUR_ANG", 1.965639);
         concurrentMap.put("EUR_USD", 1.088186);
 
-        when(cacheManager.getCache("exchangeRate")).thenReturn(caffeineCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(caffeineCache);
 
         com.github.benmanes.caffeine.cache.Cache nativeCache = mock(com.github.benmanes.caffeine.cache.Cache.class);
 
@@ -70,7 +70,7 @@ class CacheService_unitTest {
     @Test
     void whenNoCache_getAllEntries_throwException(){
         // Set up Expectations
-        when(cacheManager.getCache("exchangeRate")).thenReturn(null);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(null);
 
         // Verify the result is as expected
         assertThatThrownBy(() -> cacheService.getAllCacheEntries())
@@ -81,7 +81,7 @@ class CacheService_unitTest {
     @Test
     void whenCacheEmpty_getAllKeys_returnEmpty(){
         // Set up Expectations
-        when(cacheManager.getCache("exchangeRate")).thenReturn(caffeineCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(caffeineCache);
 
         com.github.benmanes.caffeine.cache.Cache nativeCache = mock(com.github.benmanes.caffeine.cache.Cache.class);
 
@@ -100,7 +100,7 @@ class CacheService_unitTest {
         concurrentMap.put("EUR_ANG", 1.965639);
         concurrentMap.put("EUR_USD", 1.088186);
 
-        when(cacheManager.getCache("exchangeRate")).thenReturn(caffeineCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(caffeineCache);
 
         com.github.benmanes.caffeine.cache.Cache nativeCache = mock(com.github.benmanes.caffeine.cache.Cache.class);
 
@@ -114,7 +114,7 @@ class CacheService_unitTest {
     @Test
     void whenNoCache_getAllKeys_throwException(){
         // Set up Expectations
-        when(cacheManager.getCache("exchangeRate")).thenReturn(null);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(null);
 
         // Verify the result is as expected
         assertThatThrownBy(() -> cacheService.getAllCacheKeys())
@@ -125,7 +125,7 @@ class CacheService_unitTest {
     @Test
     void whenCacheEmpty_getSingleValue_returnEmpty(){
         // Set up Expectations
-        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(exchangeRateCache);
 
         when(exchangeRateCache.get("EUR_AMD")).thenReturn(null);
 
@@ -139,7 +139,7 @@ class CacheService_unitTest {
     @Test
     void whenCacheFull_getSingleValue_returnCorrect(){
         // Set up Expectations
-        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(exchangeRateCache);
 
         Cache.ValueWrapper cachedValue = mock(Cache.ValueWrapper.class);
         when(cachedValue.get()).thenReturn(422.228721);
@@ -155,7 +155,7 @@ class CacheService_unitTest {
     @Test
     void whenNoCache_getSingleValue_throwException(){
         // Set up Expectations
-        when(cacheManager.getCache("exchangeRate")).thenReturn(null);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(null);
 
         // Verify the result is as expected
         assertThatThrownBy(() -> cacheService.getSingleValue("EUR_AMD"))
@@ -166,7 +166,7 @@ class CacheService_unitTest {
     @Test
     void whenNoCache_deleteCache_throwException(){
         // Set up Expectations
-        when(cacheManager.getCache("exchangeRate")).thenReturn(null);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(null);
 
         // Verify the result is as expected
         assertThatThrownBy(() -> cacheService.deleteAllCacheEntries())
@@ -177,7 +177,7 @@ class CacheService_unitTest {
     @Test
     void whenCacheEmpty_getStatistics_returnEmpty(){
         // Set up Expectations
-        when(cacheManager.getCache("exchangeRate")).thenReturn(caffeineCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(caffeineCache);
 
         com.github.benmanes.caffeine.cache.Cache nativeCache = mock(com.github.benmanes.caffeine.cache.Cache.class);
         com.github.benmanes.caffeine.cache.stats.CacheStats cacheStats = mock(com.github.benmanes.caffeine.cache.stats.CacheStats.class);
@@ -200,7 +200,7 @@ class CacheService_unitTest {
     @Test
     void whenCacheFull_getStatistics_returnCorrect(){
         // Set up Expectations
-        when(cacheManager.getCache("exchangeRate")).thenReturn(caffeineCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(caffeineCache);
 
         com.github.benmanes.caffeine.cache.Cache nativeCache = mock(com.github.benmanes.caffeine.cache.Cache.class);
         com.github.benmanes.caffeine.cache.stats.CacheStats cacheStats = mock(com.github.benmanes.caffeine.cache.stats.CacheStats.class);
@@ -222,7 +222,7 @@ class CacheService_unitTest {
     @Test
     void whenNoCache_getStatistics_throwException(){
         // Set up Expectations
-        when(cacheManager.getCache("exchangeRate")).thenReturn(null);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(null);
 
         // Verify the result is as expected
         assertThatThrownBy(() -> cacheService.getAllStatistics())

--- a/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ConversionService_unitTest.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ConversionService_unitTest.java
@@ -82,9 +82,9 @@ class ConversionService_unitTest {
         when(exchangeService.getExchangeRatesFromExternalAPI("EUR", "AMD,USD,")).thenReturn(exchangeRatesFromExternalApi);
 
         // Verify the result is as expected
-        Map<String, Double> exchangeRate = conversionService.getConversionForVariousCurrencies("EUR", "AMD,USD", 50.0);
+        Map<String, Double> conversions = conversionService.getConversionFromCurrency("EUR", "AMD,USD", 50.0);
 
-        assertThat(exchangeRate).containsOnlyKeys("AMD", "USD")
+        assertThat(conversions).containsOnlyKeys("AMD", "USD")
                 .containsEntry("USD",54.4093)
                 .containsEntry("AMD",21111.43605);
 
@@ -110,9 +110,9 @@ class ConversionService_unitTest {
         when(exchangeService.getExchangeRateFromCache("EUR", "USD")).thenReturn(1.088186);
 
         // Verify the result is as expected
-        Map<String, Double> exchangeRate = conversionService.getConversionForVariousCurrencies("EUR", "AMD,USD", 50.0);
+        Map<String, Double> conversions = conversionService.getConversionFromCurrency("EUR", "AMD,USD", 50.0);
 
-        assertThat(exchangeRate).containsOnlyKeys("AMD", "USD")
+        assertThat(conversions).containsOnlyKeys("AMD", "USD")
                 .containsEntry("USD",54.4093)
                 .containsEntry("AMD",21111.43605);
 
@@ -143,9 +143,9 @@ class ConversionService_unitTest {
         when(exchangeService.getExchangeRatesFromExternalAPI("EUR", "USD,")).thenReturn(exchangeRatesFromExternalApi);
 
         // Verify the result is as expected
-        Map<String, Double> exchangeRate = conversionService.getConversionForVariousCurrencies("EUR", "AMD,USD", 50.0);
+        Map<String, Double> conversions = conversionService.getConversionFromCurrency("EUR", "AMD,USD", 50.0);
 
-        assertThat(exchangeRate).containsOnlyKeys("AMD", "USD")
+        assertThat(conversions).containsOnlyKeys("AMD", "USD")
                 .containsEntry("USD",54.4093)
                 .containsEntry("AMD",21111.43605);
 
@@ -175,7 +175,7 @@ class ConversionService_unitTest {
         when(exchangeService.getExchangeRatesFromExternalAPI("EUR", "AMD,USD,")).thenThrow(new ExternalApiConnectionError("External API request failed"));
 
         // Verify the result is as expected
-        assertThatThrownBy(() -> conversionService.getConversionForVariousCurrencies("EUR", "AMD,USD", 50.0))
+        assertThatThrownBy(() -> conversionService.getConversionFromCurrency("EUR", "AMD,USD", 50.0))
                 .isInstanceOf(ExternalApiConnectionError.class)
                 .hasMessage("External API request failed");
 
@@ -194,7 +194,7 @@ class ConversionService_unitTest {
         when(currencyRepository.existsByCode("USD")).thenReturn(true);
 
         // Verify the result is as expected
-        assertThatThrownBy(() -> conversionService.getConversionForVariousCurrencies("ZZZ", "AMD,ANG,USD", 50.0))
+        assertThatThrownBy(() -> conversionService.getConversionFromCurrency("ZZZ", "AMD,ANG,USD", 50.0))
                 .isInstanceOf(InvalidCurrencyException.class)
                 .hasMessage("Invalid currency code ZZZ provided!");
 
@@ -209,7 +209,7 @@ class ConversionService_unitTest {
         when(currencyRepository.existsByCode("USD")).thenReturn(true);
 
         // Verify the result is as expected
-        assertThatThrownBy(() -> conversionService.getConversionForVariousCurrencies("AMD", "ZZZ,ANG,USD", 50.0))
+        assertThatThrownBy(() -> conversionService.getConversionFromCurrency("AMD", "ZZZ,ANG,USD", 50.0))
                 .isInstanceOf(InvalidCurrencyException.class)
                 .hasMessage("Invalid currency code ZZZ provided!");
 
@@ -230,16 +230,17 @@ class ConversionService_unitTest {
         // Exchange Service calls
         when(exchangeService.getExchangeRateFromCache("EUR", "USD")).thenReturn(null);
 
-        when(exchangeService.getExchangeRatesFromExternalAPI("EUR", "USD")).thenReturn(exchangeRatesFromExternalApi);
+        when(exchangeService.getExchangeRatesFromExternalAPI("EUR", "USD,")).thenReturn(exchangeRatesFromExternalApi);
 
         // Verify the result is as expected
-        Double conversionValue = conversionService.getConversionForSpecificCurrency("EUR", "USD", 50.0);
+        Map<String, Double> conversions = conversionService.getConversionFromCurrency("EUR", "USD", 50.0);
 
-        assertThat(conversionValue).isEqualTo(54.4093);
+        assertThat(conversions).containsOnlyKeys("USD")
+                .containsEntry("USD",54.4093);
 
         // Method invocation verifications
         verify(exchangeService, times(1)).getExchangeRateFromCache("EUR", "USD");
-        verify(exchangeService, times(1)).getExchangeRatesFromExternalAPI("EUR", "USD");
+        verify(exchangeService, times(1)).getExchangeRatesFromExternalAPI("EUR", "USD,");
     }
 
     @Test
@@ -256,9 +257,10 @@ class ConversionService_unitTest {
         when(exchangeService.getExchangeRateFromCache("EUR", "USD")).thenReturn(1.088186);
 
         // Verify the result is as expected
-        Double conversionValue = conversionService.getConversionForSpecificCurrency("EUR", "USD", 50.0);
+        Map<String, Double> conversions = conversionService.getConversionFromCurrency("EUR", "USD", 50.0);
 
-        assertThat(conversionValue).isEqualTo(54.4093);
+        assertThat(conversions).containsOnlyKeys("USD")
+                .containsEntry("USD",54.4093);
 
         // Method invocation verifications
         verify(exchangeService, times(1)).getExchangeRateFromCache("EUR", "USD");
@@ -276,16 +278,16 @@ class ConversionService_unitTest {
         // Exchange Service calls
         when(exchangeService.getExchangeRateFromCache("EUR", "USD")).thenReturn(null);
 
-        when(exchangeService.getExchangeRatesFromExternalAPI("EUR", "USD")).thenThrow(new ExternalApiConnectionError("External API request failed"));
+        when(exchangeService.getExchangeRatesFromExternalAPI("EUR", "USD,")).thenThrow(new ExternalApiConnectionError("External API request failed"));
 
         // Verify the result is as expected
-        assertThatThrownBy(() -> conversionService.getConversionForSpecificCurrency("EUR", "USD", 50.0))
+        assertThatThrownBy(() -> conversionService.getConversionFromCurrency("EUR", "USD", 50.0))
                 .isInstanceOf(ExternalApiConnectionError.class)
                 .hasMessage("External API request failed");
 
         // Method invocation verifications
         verify(exchangeService, times(1)).getExchangeRateFromCache("EUR", "USD");
-        verify(exchangeService, times(1)).getExchangeRatesFromExternalAPI("EUR", "USD");
+        verify(exchangeService, times(1)).getExchangeRatesFromExternalAPI("EUR", "USD,");
     }
 
     @Test
@@ -295,9 +297,9 @@ class ConversionService_unitTest {
         when(currencyRepository.existsByCode("ZZZ")).thenReturn(false);
 
         // Verify the result is as expected
-        assertThatThrownBy(() -> conversionService.getConversionForSpecificCurrency("ZZZ","EUR", 50.0))
+        assertThatThrownBy(() -> conversionService.getConversionFromCurrency("ZZZ","EUR", 50.0))
                 .isInstanceOf(InvalidCurrencyException.class)
-                .hasMessage("Invalid currency code(s) provided!");
+                .hasMessage("Invalid currency code ZZZ provided!");
     }
 
     @Test
@@ -307,9 +309,9 @@ class ConversionService_unitTest {
         when(currencyRepository.existsByCode("ZZZ")).thenReturn(false);
 
         // Verify the result is as expected
-        assertThatThrownBy(() -> conversionService.getConversionForSpecificCurrency("EUR","ZZZ", 50.0))
+        assertThatThrownBy(() -> conversionService.getConversionFromCurrency("EUR","ZZZ", 50.0))
                 .isInstanceOf(InvalidCurrencyException.class)
-                .hasMessage("Invalid currency code(s) provided!");
+                .hasMessage("Invalid currency code ZZZ provided!");
     }
 
 }

--- a/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExchangeService_unitTest.java
+++ b/backend/src/test/java/com/dfc/exchange_api/backend/unitTests/ExchangeService_unitTest.java
@@ -100,7 +100,7 @@ class ExchangeService_unitTest {
         when(currencyRepository.findAll()).thenReturn(testCurrencies);
 
         // Cache calls
-        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(exchangeRateCache);
         when(exchangeRateCache.get("EUR_AMD")).thenReturn(null);
         when(exchangeRateCache.get("EUR_ANG")).thenReturn(null);
         when(exchangeRateCache.get("EUR_USD")).thenReturn(null);
@@ -133,7 +133,7 @@ class ExchangeService_unitTest {
         when(currencyRepository.findAll()).thenReturn(testCurrencies);
 
         // Cache Calls
-        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(exchangeRateCache);
         Cache.ValueWrapper cachedValue = mock(Cache.ValueWrapper.class);
         when(cachedValue.get()).thenReturn(422.228721);
 
@@ -185,7 +185,7 @@ class ExchangeService_unitTest {
         when(currencyRepository.findAll()).thenReturn(testCurrencies);
 
         // Cache calls
-        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(exchangeRateCache);
         Cache.ValueWrapper cachedValue = mock(Cache.ValueWrapper.class);
         when(cachedValue.get()).thenReturn(422.228721);
 
@@ -228,7 +228,7 @@ class ExchangeService_unitTest {
         when(currencyRepository.findAll()).thenReturn(testCurrencies);
 
         // Cache calls
-        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(exchangeRateCache);
         when(exchangeRateCache.get("EUR_AMD")).thenReturn(null);
         when(exchangeRateCache.get("EUR_ANG")).thenReturn(null);
         when(exchangeRateCache.get("EUR_USD")).thenReturn(null);
@@ -284,7 +284,7 @@ class ExchangeService_unitTest {
         when(currencyRepository.findByCode("USD")).thenReturn(Optional.of(dollar));
 
         // Cache calls
-        when(cacheManager.getCache("exchangeRate")).thenReturn(exchangeRateCache);
+        when(cacheManager.getCache(Mockito.any())).thenReturn(exchangeRateCache);
 
         // Verify the result is as expected
         Double exchangeRate = exchangeService.getExchangeRateForSpecificCurrency("EUR", "USD");


### PR DESCRIPTION
- Refactored the ExchangeController so that both operations can be done on the same endpoint.
- Refactored the ConversionController so that both operations can be done on the same endpoint.
- Refactored ConversionService, as there was no need for two methods to exist, ad the fetching of the conversion amount for a specific currency can eb done on the same method as for various currencies
- Added an edge case to return immediately 0 for conversion values when the specified amount to convert is 0, so that no fetching of exchange rates is unecessarily done from either the cache or the External API.
- Changed the ExternalAPIError custom exception HTTP status from BAD GATEWAY to SERVICE UNAVAILABLE.
- Made the External API URL and the cache name application properties, instead of instantiating a constant in every service that required them.